### PR TITLE
style: replace `border-none` with `border-transparent` for consistency

### DIFF
--- a/app/[locale]/(main)/(shar)/files/file-list.tsx
+++ b/app/[locale]/(main)/(shar)/files/file-list.tsx
@@ -74,7 +74,7 @@ export default function FileList({ path, filter, setFilePath }: FileListProps) {
       <ContextMenuItem variant="destructive" onClick={() => deleteFile(`${path}/${file.name}`)}>
         <Tran text="delete" />
       </ContextMenuItem>
-      <DownloadButton className="justify-start rounded-sm border-none px-2 py-1.5 text-sm hover:bg-brand" href={`${env.url.api}/files/download?path=${path}/${file.name}`} fileName={`file.zip`} secure>
+      <DownloadButton className="justify-start rounded-sm border-transparent px-2 py-1.5 text-sm hover:bg-brand" href={`${env.url.api}/files/download?path=${path}/${file.name}`} fileName={`file.zip`} secure>
         <Tran text="download" />
       </DownloadButton>
     </FileCard>

--- a/app/[locale]/(main)/admin/setting/(users)/user-management-card.tsx
+++ b/app/[locale]/(main)/admin/setting/(users)/user-management-card.tsx
@@ -17,7 +17,7 @@ export function UserManagementCard({ user }: Props) {
     <div className="grid w-full grid-cols-[1fr_10rem_auto] gap-4 bg-card px-4 py-2 rounded-sm">
       <div className="flex justify-between space-x-2 overflow-hidden">
         <UserAvatar user={user} url />
-        <CopyButton className="w-full justify-start overflow-hidden hover:bg-transparent bg-transparent border-none" data={user.id} content={user.id}>
+        <CopyButton className="w-full justify-start overflow-hidden hover:bg-transparent bg-transparent border-transparent" data={user.id} content={user.id}>
           <h3>{user.name}</h3>
         </CopyButton>
       </div>

--- a/app/[locale]/(main)/admin/setting/tags/delete-group-info-dialog.tsx
+++ b/app/[locale]/(main)/admin/setting/tags/delete-group-info-dialog.tsx
@@ -35,7 +35,7 @@ export default function DeleteGroupInfoDialog({ group, category }: Props) {
 
   return (
     <DeleteButton
-      className="relative transition-all bg-transparent p-0 border-none w-0 group-hover:w-fit overflow-hidden"
+      className="relative transition-all bg-transparent p-0 border-transparent w-0 group-hover:w-fit overflow-hidden"
       variant="ghost"
       isLoading={isPending}
       description={<Tran text="delete-alert" args={{ name: category.name }} />}

--- a/app/[locale]/(main)/chat/page.client.tsx
+++ b/app/[locale]/(main)/chat/page.client.tsx
@@ -99,7 +99,7 @@ function ChatInput() {
             <PopoverTrigger>
               <SmileIcon />
             </PopoverTrigger>
-            <PopoverContent className="border-none bg-transparent">
+            <PopoverContent className="border-transparent bg-transparent">
               <EmojiPicker
                 theme={theme === 'light' ? Theme.LIGHT : Theme.DARK}
                 onEmojiClick={(emoji) => {

--- a/app/[locale]/(main)/image-generator/router/page.tsx
+++ b/app/[locale]/(main)/image-generator/router/page.tsx
@@ -104,7 +104,7 @@ export default function Page() {
           <Tran text="image-generator.generating-schematic" />
         </div>
       ) : (
-        <section className="flex flex-col gap-2">
+        <section className="flex flex-wrap gap-2">
           {data?.map((item, index) => (
             <div key={index} className="border rounded-lg p-2 relative space-y-2">
               <span className="font-bold align-text-top">{index}</span>

--- a/app/[locale]/(main)/image-generator/router/page.tsx
+++ b/app/[locale]/(main)/image-generator/router/page.tsx
@@ -145,7 +145,7 @@ function Preview({ data }: { data: string }) {
       </div>
     );
   }
-  return <div>{preview && <img className="max-w-[50vw] max-h-[50vh]" src={IMAGE_PREFIX + preview.image} alt="Processed" />}</div>;
+  return <div>{preview && <img className="max-w-[50vw] max-h-[50vh] rounded-md" src={IMAGE_PREFIX + preview.image} alt="Processed" />}</div>;
 }
 
 function DownloadButton({ data }: { data: string }) {

--- a/app/[locale]/(main)/image-generator/router/page.tsx
+++ b/app/[locale]/(main)/image-generator/router/page.tsx
@@ -92,7 +92,6 @@ export default function Page() {
           <Tran text="image-generator.split-vertical" /> : {splitVertical}
           <Slider value={[splitVertical]} onValueChange={(value) => setSplitVertical(value[0])} min={1} max={4} step={1} />
         </div>
-        w
         <div className="space-y-2 w-full">
           <Tran text="image-generator.split-horizontal" /> : {splitHorizontal}
           <Slider value={[splitHorizontal]} onValueChange={(value) => setSplitHorizontal(value[0])} min={1} max={4} step={1} />

--- a/app/[locale]/(main)/logic/node.tsx
+++ b/app/[locale]/(main)/logic/node.tsx
@@ -257,7 +257,7 @@ export function NodeItem({ color, data, state, setState }: { color: string; stat
     return (
       <div className="bg-transparent border-b-[3px] flex items-end" style={{ borderColor: color }}>
         <ComboBox
-          className="bg-transparent px-2 py-0 text-center w-fit font-bold border-none items-end justify-end"
+          className="bg-transparent px-2 py-0 text-center w-fit font-bold border-transparent items-end justify-end"
           value={{ value: state[data.name], label: state[data.name].toString() }}
           values={data.options.map((option) => ({ value: option, label: option.toString() }))}
           onChange={(value) => {

--- a/app/[locale]/(main)/logs/page.client.tsx
+++ b/app/[locale]/(main)/logs/page.client.tsx
@@ -208,7 +208,7 @@ function FilterDialog({ filter, setFilter }: FilterDialogProps) {
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Button className="border-none bg-secondary shadow-md" variant="outline" title="Filter">
+        <Button className="border-transparent bg-secondary shadow-md" variant="outline" title="Filter">
           <IconNotification number={number}>
             <FilterIcon />
           </IconNotification>

--- a/app/[locale]/(main)/mindustry-gpt/chat-input-field.tsx
+++ b/app/[locale]/(main)/mindustry-gpt/chat-input-field.tsx
@@ -16,7 +16,7 @@ export default function ChatInputField({ reset, setPrompt, handleKeyPress }: Cha
   return (
     <AutosizeTextarea
       key={reset}
-      className="max-h-56 min-h-full resize-none w-full max-w-[100vw] overflow-x-hidden p-1 focus-visible:outline-none border-none focus-visible:shadow-none focus-visible:ring-offset-0 bg-transparent focus-visible:ring-transparent"
+      className="max-h-56 min-h-full resize-none w-full max-w-[100vw] overflow-x-hidden p-1 focus-visible:outline-none border-transparent focus-visible:shadow-none focus-visible:ring-offset-0 bg-transparent focus-visible:ring-transparent"
       placeholder={t('input-place-holder')}
       onChange={(event) => setPrompt(event.target.value ?? '')}
       onKeyDown={handleKeyPress}

--- a/app/[locale]/(main)/ratio/page.client.tsx
+++ b/app/[locale]/(main)/ratio/page.client.tsx
@@ -36,7 +36,7 @@ export default function RatioPage() {
       </Link>
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
-          <Button className="h-12 min-w-[200px] justify-between border-none bg-secondary p-2 capitalize shadow-md" title="" role="combobox" variant="outline">
+          <Button className="h-12 min-w-[200px] justify-between border-transparent bg-secondary p-2 capitalize shadow-md" title="" role="combobox" variant="outline">
             {value ? (
               <div className="flex items-center justify-start gap-2">
                 <Image className="h-8 w-8" src={`/assets/sprite/${value.factory.name}.png`} height={32} width={32} alt={value.factory.name} />
@@ -54,7 +54,7 @@ export default function RatioPage() {
               <div>
                 <MagnifyingGlassIcon className="size-5" />
               </div>
-              <input className="border-none bg-transparent font-thin outline-none" value={filter} placeholder="Search" onChange={(event) => setFilter(event.currentTarget.value)} />
+              <input className="border-transparent bg-transparent font-thin outline-none" value={filter} placeholder="Search" onChange={(event) => setFilter(event.currentTarget.value)} />
             </div>
             <div className="flex flex-col gap-2 p-1">
               {blocks.map((item) => (
@@ -118,7 +118,7 @@ function RequirementCard({ input }: RequirementCardProps) {
               <div>
                 <MagnifyingGlassIcon className="size-5" />
               </div>
-              <input className="border-none bg-transparent font-thin outline-none" value={filter} placeholder="Search" onChange={(event) => setFilter(event.currentTarget.value)} />
+              <input className="border-transparent bg-transparent font-thin outline-none" value={filter} placeholder="Search" onChange={(event) => setFilter(event.currentTarget.value)} />
             </div>
             <div className="grid gap-2 p-1">
               {filtered.map((item) => (

--- a/app/[locale]/(main)/servers/[id]/env/page.client.tsx
+++ b/app/[locale]/(main)/servers/[id]/env/page.client.tsx
@@ -116,7 +116,7 @@ function ServerEnvCard({ id, env }: ServerEnvCardProps) {
               <FormItem className="w-full">
                 <FormControl>
                   <div className="border-border border rounded-md flex items-center gap-2 h-9">
-                    {show ? <Input className="w-full border-none" key="input" placeholder="ghp_awdguyagwdygawdagwiy" {...field} /> : <Input readOnly className="w-full border-none" defaultValue={'*'.repeat(field.value.length)} />}
+                    {show ? <Input className="w-full border-transparent" key="input" placeholder="ghp_awdguyagwdygawdagwiy" {...field} /> : <Input readOnly className="w-full border-transparent" defaultValue={'*'.repeat(field.value.length)} />}
                     <Button className="px-2" variant="ghost" onClick={() => setShow((prev) => !prev)}>
                       {show ? <EyeOffIcon /> : <EyeIcon />}
                     </Button>

--- a/app/[locale]/(main)/servers/[id]/files/file-list.tsx
+++ b/app/[locale]/(main)/servers/[id]/files/file-list.tsx
@@ -74,7 +74,7 @@ export default function FileList({ id, path, filter, setFilePath }: FileListProp
       <ContextMenuItem variant="destructive" onClick={() => deleteFile(`${path}/${file.name}`)}>
         <Tran text="delete" />
       </ContextMenuItem>
-      <DownloadButton className="justify-start rounded-sm border-none px-2 py-1.5 text-sm hover:bg-brand" href={`${env.url.api}/files/download?path=${path}/${file.name}`} fileName={`file.zip`} secure>
+      <DownloadButton className="justify-start rounded-sm border-transparent px-2 py-1.5 text-sm hover:bg-brand" href={`${env.url.api}/files/download?path=${path}/${file.name}`} fileName={`file.zip`} secure>
         <Tran text="download" />
       </DownloadButton>
     </FileCard>

--- a/app/[locale]/(main)/translation/compare-table.tsx
+++ b/app/[locale]/(main)/translation/compare-table.tsx
@@ -110,7 +110,7 @@ function CompareCard({ translation, language, target }: CompareCardProps) {
         <div className="flex items-center gap-2" onClick={() => setEdit(true)}>
           {isEdit ? ( //
             <Textarea
-              className="min-h-full border-none p-0 outline-none ring-0 focus-visible:outline-none focus-visible:ring-0"
+              className="min-h-full border-transparent p-0 outline-none ring-0 focus-visible:outline-none focus-visible:ring-0"
               defaultValue={currentValue ?? key}
               onChange={(event) => setCurrentValue(event.target.value)}
               onBlur={() => {

--- a/app/[locale]/(main)/translation/diff-table.tsx
+++ b/app/[locale]/(main)/translation/diff-table.tsx
@@ -104,7 +104,7 @@ function DiffCard({ translation, language }: DiffCardProps) {
         <div className="flex items-center gap-2" onClick={() => setEdit(true)}>
           {isEdit ? ( //
             <Textarea
-              className="border-none p-0 outline-none ring-0 focus-visible:outline-none focus-visible:ring-0"
+              className="border-transparent p-0 outline-none ring-0 focus-visible:outline-none focus-visible:ring-0"
               placeholder={currentValue ?? key}
               defaultValue={currentValue ?? key}
               onChange={(event) => setCurrentValue(event.target.value)}

--- a/app/[locale]/(main)/translation/search-table.tsx
+++ b/app/[locale]/(main)/translation/search-table.tsx
@@ -96,7 +96,7 @@ function SearchCard({ translation }: SearchCardProps) {
           <div className="w-full" onClick={() => setEdit(true)}>
             {isEdit ? ( //
               <Textarea
-                className="border-none p-0 outline-none ring-0 focus-visible:outline-none focus-visible:ring-0"
+                className="border-transparent p-0 outline-none ring-0 focus-visible:outline-none focus-visible:ring-0"
                 autoFocus
                 defaultValue={currentValue ?? key}
                 onChange={(event) => setCurrentValue(event.target.value)}

--- a/app/[locale]/(main)/users/[id]/user-detail.tsx
+++ b/app/[locale]/(main)/users/[id]/user-detail.tsx
@@ -51,7 +51,7 @@ export default function UserDetail({ user }: Props) {
       )}
       <div className="relative flex gap-2 bg-card bg-cover bg-center p-2">
         <UserAvatar className="h-20 w-20 min-w-20 min-h-20" user={user} />
-        <EllipsisButton className="absolute right-2 top-2 aspect-square border-none bg-transparent" variant="ghost">
+        <EllipsisButton className="absolute right-2 top-2 aspect-square border-transparent bg-transparent" variant="ghost">
           <ProtectedElement session={session} filter={{ authorId: user.id }}>
             <InternalLink variant="command" href="/users/@me/setting">
               <EditIcon />

--- a/app/[locale]/docs/doc-search-bar.tsx
+++ b/app/[locale]/docs/doc-search-bar.tsx
@@ -48,7 +48,7 @@ export default function DocSearchBar() {
         </Hidden>
         <div className="border h-8 rounded-lg px-2 py-0.5 flex items-center w-full">
           <SearchIcon />
-          <Input className={cn('w-0 border-none focus:border-brand', { 'w-full': focus })} placeholder={t('search')} type="text" value={query} onChange={(event) => setQuery(event.currentTarget.value)} onFocus={() => setFocus(true)} />
+          <Input className={cn('w-0 border-transparent focus:border-brand', { 'w-full': focus })} placeholder={t('search')} type="text" value={query} onChange={(event) => setQuery(event.currentTarget.value)} onFocus={() => setFocus(true)} />
         </div>
         {data && focus && (
           <div className="grid gap-2 mt-2 max-h-dvh overflow-y-auto">

--- a/app/[locale]/docs/language-switcher.tsx
+++ b/app/[locale]/docs/language-switcher.tsx
@@ -32,7 +32,7 @@ export default function LanguageSwitcher({ availableLanguages, currentLocale }: 
         <div className="grid gap-1 p-1 max-h-[50dvh] overflow-y-auto">
           {locales.map((locale) => (
             <button
-              className={cn('px-2 text-muted-foreground py-1 inline-flex rounded-md min-w-32 h-9 justify-start items-center capitalize border-none focus:border-none', {
+              className={cn('px-2 text-muted-foreground py-1 inline-flex rounded-md min-w-32 h-9 justify-start items-center capitalize border-transparent focus:border-transparent', {
                 'bg-brand text-brand-foreground': locale === currentLocale,
                 'hover:bg-brand hover:text-brand-foreground text-brand-foreground': availableLanguages.includes(locale),
               })}

--- a/app/globals.css
+++ b/app/globals.css
@@ -173,7 +173,7 @@
   }
 
   g path {
-    @apply focus:border-none focus:outline-none;
+    @apply focus:border-transparent focus:outline-none;
   }
 
   * {

--- a/components/button/copy-button.tsx
+++ b/components/button/copy-button.tsx
@@ -14,7 +14,7 @@ import { useMutation } from '@tanstack/react-query';
 const copyButtonVariants = cva('p-2 bg-transparent group/copy-button', {
   variants: {
     variant: {
-      default: 'bg-secondary border border-border hover:bg-brand hover:border-none',
+      default: 'bg-secondary border border-border hover:bg-brand hover:border-transparent',
       ghost: 'bg-none bg-card/70 backdrop-blur-sm backdrop-brightness-50 hidden group-hover:flex hidden group-focus:flex',
       none: '',
     },

--- a/components/button/delete-button.tsx
+++ b/components/button/delete-button.tsx
@@ -15,7 +15,7 @@ const buttonVariants = cva('hover:bg-destructive/80', {
     variant: {
       command: '',
       default: 'border border-border bg-transparent bg-secondary hover:border-destructive',
-      ghost: 'border-none absolute w-fit backdrop-brightness-50 hover:border-none',
+      ghost: 'border-transparent absolute w-fit backdrop-brightness-50 hover:border-transparent',
     },
   },
   defaultVariants: {

--- a/components/button/download-button.tsx
+++ b/components/button/download-button.tsx
@@ -30,7 +30,7 @@ export default function DownloadButton({ className, href, fileName, secure, chil
 
   return (
     <a
-      className={cn('flex gap-1 px-2 min-h-8 items-center hover:border-none transition-colors text-lg justify-center rounded-md bg-secondary border-border border hover:bg-brand hover:text-brand-foreground', className)}
+      className={cn('flex gap-1 px-2 min-h-8 items-center hover:border-transparent transition-colors text-lg justify-center rounded-md bg-secondary border-border border hover:bg-brand hover:text-brand-foreground', className)}
       {...props}
       href={href}
       download={fileName ?? true}

--- a/components/button/remove-button.tsx
+++ b/components/button/remove-button.tsx
@@ -16,7 +16,7 @@ type RemoveButtonProps = {
 export default function RemoveButton({ isLoading, description, onClick }: RemoveButtonProps) {
   return (
     <AlertDialog>
-      <AlertDialogTrigger className="flex items-center justify-center rounded-md border p-2 hover:border-none" disabled={isLoading}>
+      <AlertDialogTrigger className="flex items-center justify-center rounded-md border p-2 hover:border-transparent" disabled={isLoading}>
         <TrashIcon />
       </AlertDialogTrigger>
       <AlertDialogContent>

--- a/components/button/verify-button.tsx
+++ b/components/button/verify-button.tsx
@@ -16,7 +16,7 @@ type VerifyButtonProps = {
 export default function VerifyButton({ isLoading, description, onClick }: VerifyButtonProps) {
   return (
     <AlertDialog>
-      <AlertDialogTrigger className="flex items-center justify-center rounded-md border p-2 hover:bg-success hover:border-none border-border bg-secondary" disabled={isLoading}>
+      <AlertDialogTrigger className="flex items-center justify-center rounded-md border p-2 hover:bg-success hover:border-transparent border-border bg-secondary" disabled={isLoading}>
         <CheckIcon className="size-5" />
       </AlertDialogTrigger>
       <AlertDialogContent>

--- a/components/common/bulk-action.tsx
+++ b/components/common/bulk-action.tsx
@@ -95,7 +95,7 @@ export function BulkDeleteToggle() {
     return (
       <AlertDialog>
         <AlertDialogTrigger asChild>
-          <Button className="border-none" variant="secondary">
+          <Button className="border-transparent" variant="secondary">
             <Tran text="selected" args={{ number: value.length }} />
           </Button>
         </AlertDialogTrigger>
@@ -124,7 +124,7 @@ export function BulkDeleteToggle() {
   }
 
   return (
-    <Button className="border-none" variant="secondary" onClick={() => setShow(!show)}>
+    <Button className="border-transparent" variant="secondary" onClick={() => setShow(!show)}>
       {value.length === 0 && show ? <Tran text="cancel" /> : <Tran text="bulk-delete" />}
     </Button>
   );

--- a/components/common/combo-box.tsx
+++ b/components/common/combo-box.tsx
@@ -71,7 +71,7 @@ export default function ComboBox<T>({ className, placeholder = 'Select', values,
               <div>
                 <SearchIcon className="size-5" />
               </div>
-              <input className="border-none bg-transparent font-thin outline-none" value={input} placeholder="Search" onChange={(event) => setInput(event.currentTarget.value)} />
+              <input className="border-transparent bg-transparent font-thin outline-none" value={input} placeholder="Search" onChange={(event) => setInput(event.currentTarget.value)} />
             </div>
           )}
           <div className="grid gap-1 p-1 max-h-[50dvh] overflow-y-auto">

--- a/components/common/comment-section.tsx
+++ b/components/common/comment-section.tsx
@@ -202,7 +202,7 @@ function CommentInput({ itemId }: CommentInputProps) {
               <FormItem className="w-full">
                 <FormControl>
                   <AutosizeTextarea
-                    className="focus-visible:outline-none border-transparent focus-visible:ring-transparent border-none focus-visible:border-none resize-none"
+                    className="focus-visible:outline-none border-transparent focus-visible:ring-transparent border-transparent focus-visible:border-transparent resize-none"
                     placeholder={t('add-comment')}
                     ref={inputRef}
                     value={field.value}

--- a/components/common/size-selector.tsx
+++ b/components/common/size-selector.tsx
@@ -31,7 +31,7 @@ export default function SizeSelector({ sizes }: SizeSelectorProps) {
 
   return (
     <ComboBox
-      className="w-20 rounded-md border-none h-10 bg-card"
+      className="w-20 rounded-md border-transparent h-10 bg-card"
       searchBar={false}
       value={{ label: size.toString(), value: size }}
       values={sizes.map((size) => ({

--- a/components/common/tran.tsx
+++ b/components/common/tran.tsx
@@ -11,19 +11,21 @@ type Props = {
   style?: React.CSSProperties;
   args?: Record<string, any>;
   asChild?: boolean;
+  defaultValue?: string;
 };
 
-export default function Tran({ className, text, args, asChild, ...rest }: Props): React.ReactNode {
+export default function Tran({ className, text, args = {}, asChild, defaultValue, ...rest }: Props): React.ReactNode {
   const { group, key } = extractTranslationKey(text);
   const { t } = useI18n(group);
 
   if (asChild) {
-    return t(key, args);
+    return t(key, { ...args, defaultValue });
   }
 
   return (
     <span className={className} {...rest}>
-      {t(key, args)}
+      {t(key, { ...args, defaultValue })}
     </span>
   );
 }
+

--- a/components/markdown/markdown-editor.tsx
+++ b/components/markdown/markdown-editor.tsx
@@ -126,7 +126,7 @@ export default function MarkdownEditor({ value, onChange, defaultMode = 'live' }
       >
         {(mode === 'edit' || mode === 'live') && (
           <textarea
-            className="h-full w-full resize-none overflow-y-auto border-none bg-transparent p-2 outline-none"
+            className="h-full w-full resize-none overflow-y-auto border-transparent bg-transparent p-2 outline-none"
             ref={inputRef}
             title={'content'}
             value={value.text}

--- a/components/ui/ellipsis-button.tsx
+++ b/components/ui/ellipsis-button.tsx
@@ -30,7 +30,7 @@ const EllipsisButton = ({ className, variant, children, ...props }: Props) => {
           <EllipsisIcon />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="bg-transparent border-none p-0">
+      <PopoverContent className="bg-transparent border-transparent p-0">
         <Suspense>
           <div className="gap-1 p-1 text-sm font-light grid border bg-card rounded-md">{children}</div>
         </Suspense>

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -17,10 +17,10 @@ const Toaster = ({ ...props }: ToasterProps) => {
   return (
     <Sonner
       theme={theme as ToasterProps['theme']}
-      className="toaster group border-none p-4 m-1"
+      className="toaster group border-transparent p-4 m-1"
       toastOptions={{
         classNames: {
-          toast: 'group p-0 border-none group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:shadow-lg',
+          toast: 'group p-0 border-transparent group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:shadow-lg',
           description: 'group-[.toast]:text-muted-foreground',
           actionButton: 'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
           cancelButton: 'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',
@@ -40,7 +40,7 @@ type ToastOptions = {
 function toast(title: ReactNode, options?: ToastOptions) {
   if (options?.description) {
     const id = defaultToast(
-      <div className={cn('grid text-base border-none w-full rounded-lg relative p-4', options.className)}>
+      <div className={cn('grid text-base border-transparent w-full rounded-lg relative p-4', options.className)}>
         <div className="size-4 absolute top-2 right-2 text-white cursor-pointer" onClick={() => defaultToast.dismiss(id)}>
           <XIcon className="size-4" />
         </div>
@@ -59,7 +59,7 @@ function toast(title: ReactNode, options?: ToastOptions) {
   }
 
   const id = defaultToast(
-    <div className={cn('relative grid text-sm border-none w-full rounded-lg p-4', options?.className)}>
+    <div className={cn('relative grid text-sm border-transparent w-full rounded-lg p-4', options?.className)}>
       <div className="size-4 absolute top-2 right-2 text-white cursor-pointer" onClick={() => defaultToast.dismiss(id)}>
         <XIcon className="size-4" />
       </div>


### PR DESCRIPTION
This commit updates CSS classes across multiple components to use `border-transparent` instead of `border-none` for better consistency in styling. The change ensures a uniform approach to handling transparent borders throughout the application.