### PR TITLE
fix: add timeout to schematic preview request and warn for large imag…

### DIFF
--- a/app/[locale]/(main)/image-generator/router/page.tsx
+++ b/app/[locale]/(main)/image-generator/router/page.tsx
@@ -86,6 +86,9 @@ export default function Page() {
           <div>
             <Tran text="image-generator.total-blocks" /> {splitHorizontal * splitVertical} blocks
           </div>
+          <div>
+            {splitHorizontal * splitVertical > 500 * 500 && <Tran className='text-destructive' text="image-generator.too-big-may-fail" />}
+          </div>
         </div>
       )}
       <div className="space-y-2">

--- a/query/schematic.ts
+++ b/query/schematic.ts
@@ -29,6 +29,7 @@ export async function getSchematicPreview(axios: AxiosInstance, { data }: Schema
 
   const result = await axios.post('/schematics/preview', form, {
     data: form,
+    timeout: 300000
   });
 
   return result.data;


### PR DESCRIPTION
…e generation

Add a timeout of 300000ms to the schematic preview request to prevent long-running requests from hanging. Additionally, display a warning message when the image generation blocks exceed 500x500 to alert users of potential failures due to large sizes.