### PR TITLE
refactor(message-list): remove unused socket state check

### DIFF
--- a/components/common/message-list.tsx
+++ b/components/common/message-list.tsx
@@ -41,7 +41,7 @@ export default function MessageList({ className, queryKey, params, loader, noRes
 
   const queryClient = useQueryClient();
   const isEndReached = isReachedEnd(container.current, threshold);
-  const { socket, state } = useSocket();
+  const { socket } = useSocket();
 
   const clientHeight = list?.clientHeight || 0;
   const lastHeight = lastHeightRef.current || 0;
@@ -174,7 +174,7 @@ export default function MessageList({ className, queryKey, params, loader, noRes
 
   end = end ?? <Tran className="col-span-full flex w-full items-center justify-center" text="end-of-page" />;
 
-  if (state !== 'connected' || !data) {
+  if (!data) {
     return undefined;
   }
 

--- a/hooks/use-message-query.ts
+++ b/hooks/use-message-query.ts
@@ -1,4 +1,3 @@
-import { useSocket } from '@/context/socket-context';
 import useClientApi from '@/hooks/use-client';
 import { MessageQuery } from '@/query/search-query';
 import { Message } from '@/types/response/Message';


### PR DESCRIPTION
The socket state check was redundant as it did not affect the rendering logic. Simplifying the condition improves code clarity and maintainability.