### PR TITLE
style(layout): remove unnecessary gap in admin setting layout

### DIFF
--- a/app/[locale]/(main)/admin/setting/layout.tsx
+++ b/app/[locale]/(main)/admin/setting/layout.tsx
@@ -70,7 +70,7 @@ export default async function ServerLayout({ children }: LayoutProps) {
   const session = await getSession();
 
   return (
-    <div className="grid h-full grid-flow-row grid-rows-[48px_1fr] gap-2 overflow-hidden">
+    <div className="grid h-full grid-flow-row grid-rows-[48px_1fr] overflow-hidden">
       <NavLinkProvider>
         <NavLinkContainer>
           {links.map((item) => (


### PR DESCRIPTION
The gap between grid rows was redundant and caused layout inconsistencies. Removing it ensures a cleaner and more consistent UI.