### PR TITLE
fix(use-client): ensure error rejection in axios interceptor

### DIFF
--- a/hooks/use-client.tsx
+++ b/hooks/use-client.tsx
@@ -80,8 +80,11 @@ export default function useClientApi(): AxiosInstance {
             toast.error(<Tran text="internal-server-error" />);
           }
         }
+
+        return Promise.reject(error);
       },
     );
+    
 
     return () => {
       axiosInstance.interceptors.response.eject(id);


### PR DESCRIPTION
The axios interceptor was not returning a rejected promise, which could lead to unhandled errors in the application. This commit ensures that errors are properly rejected by returning `Promise.reject(error)` in the interceptor.