### PR TITLE
style: remove flex-wrap from pagination layout for consistency

### DIFF
--- a/app/[locale]/(main)/admin/maps/page.client.tsx
+++ b/app/[locale]/(main)/admin/maps/page.client.tsx
@@ -74,7 +74,7 @@ export default function Client() {
             </GridPaginationList>
           </GridLayout>
         </ScrollContainer>
-        <div className="flex flex-wrap items-center gap-2 justify-between">
+        <div className="flex items-center gap-2 justify-between">
           <BulkDeleteToggle />
           <div className="flex items-center gap-2">
             <PaginationLayoutSwitcher />

--- a/app/[locale]/(main)/admin/schematics/page.client.tsx
+++ b/app/[locale]/(main)/admin/schematics/page.client.tsx
@@ -73,7 +73,7 @@ export default function Client() {
             </GridPaginationList>
           </GridLayout>
         </ScrollContainer>
-        <div className="flex flex-wrap items-center gap-2 justify-between">
+        <div className="flex items-center gap-2 justify-between">
           <BulkDeleteToggle />
           <div className="flex items-center gap-2">
             <PaginationLayoutSwitcher />

--- a/app/[locale]/(main)/maps/page.tsx
+++ b/app/[locale]/(main)/maps/page.tsx
@@ -36,7 +36,7 @@ export default async function Page() {
     <div className="flex h-full flex-col gap-2 overflow-hidden p-2">
       <NameTagSearch type="map" />
       <Client />
-      <div className="flex flex-wrap items-center gap-2 justify-between">
+      <div className="flex items-center gap-2 justify-between">
         <InternalLink variant="button-secondary" href={`${env.url.base}/upload/map`}>
           <UploadIcon className="size-5" />
           <Tran text="map.upload" />

--- a/app/[locale]/(main)/schematics/page.tsx
+++ b/app/[locale]/(main)/schematics/page.tsx
@@ -43,7 +43,7 @@ export default async function Page() {
     <div className="flex h-full flex-col gap-2 overflow-hidden p-2">
       <NameTagSearch type="schematic" />
       <Client />
-      <div className="flex flex-wrap items-center gap-2 justify-between">
+      <div className="flex items-center gap-2 justify-between">
         <InternalLink variant="button-secondary" href={uploadLink}>
           <UploadIcon />
           <Tran text="upload-schematic" />

--- a/components/common/pagination-layout.tsx
+++ b/components/common/pagination-layout.tsx
@@ -18,7 +18,7 @@ export function PaginationLayoutSwitcher() {
   } = useSession();
 
   return (
-    <div className="bg-card rounded-md overflow-hidden shadow-md">
+    <div className="bg-card rounded-md overflow-hidden shadow-md flex">
       <button
         className={cn('p-2 h-full', {
           'bg-secondary hover:bg-secondary bg-opacity-80 text-secondary-foreground': paginationType === 'grid',


### PR DESCRIPTION
The flex-wrap property was removed from multiple pagination layout components to ensure consistent styling across the application. This change aligns the layout behavior and improves visual consistency.