### PR TITLE
refactor(like): simplify like component data handling

### DIFF
--- a/app/[locale]/client-init.tsx
+++ b/app/[locale]/client-init.tsx
@@ -1,10 +1,11 @@
 'use client';
 
+import { useInterval } from 'usehooks-ts';
+
 import useClientApi from '@/hooks/use-client';
 import { Batcher } from '@/lib/batcher';
 
 import { useQuery } from '@tanstack/react-query';
-import { useInterval } from 'usehooks-ts';
 
 export default function ClientInit() {
   const axios = useClientApi();
@@ -16,7 +17,7 @@ export default function ClientInit() {
 
   useInterval(async () => {
     await Batcher.process();
-  }, 100)
+  }, 50);
 
   return undefined;
 }

--- a/components/like/like-and-dislike.tsx
+++ b/components/like/like-and-dislike.tsx
@@ -1,28 +1,46 @@
-'use client'
+'use client';
 
 import DislikeButton from '@/components/like/dislike-button';
 import LikeButton from '@/components/like/like-button';
 import LikeComponent from '@/components/like/like-component';
+
 import { useSession } from '@/context/session-context';
 import { Batcher } from '@/lib/batcher';
+import { Like } from '@/types/response/Like';
 
 import { useQuery } from '@tanstack/react-query';
 
 type Props = {
-  itemId: string
+  itemId: string;
   like: number;
   dislike: number;
 };
+
+export type LikeData = {
+  data: Like;
+  like: number;
+  dislike: number;
+};
+
 export default function LikeAndDislike({ itemId, like, dislike }: Props) {
-  const { state } = useSession()
+  const { state } = useSession();
   const { data } = useQuery({
     queryKey: ['like', itemId],
-    queryFn: () => Batcher.like.get(itemId),
-    enabled: state === 'authenticated'
-  })
+    queryFn: () =>
+      Batcher.like.get(itemId).then((data) => ({
+        data: data ?? {
+          userId: '',
+          itemId,
+          state: 0,
+        },
+        like: like,
+        dislike: dislike,
+      })),
+    enabled: state === 'authenticated',
+  });
 
   return (
-    <LikeComponent initialLikeCount={like} initialDislikeCount={dislike} itemId={itemId} initialLikeData={data} >
+    <LikeComponent itemId={itemId} data={data}>
       <LikeButton />
       <DislikeButton />
     </LikeComponent>


### PR DESCRIPTION
Remove local state management in LikeComponent and rely on query data for like and dislike counts. This reduces redundancy and improves consistency with the data fetched from the server.