### PR TITLE
fix(image-generator): correct API endpoint path in image generator ro…

### DIFF
--- a/app/[locale]/(main)/image-generator/router/page.tsx
+++ b/app/[locale]/(main)/image-generator/router/page.tsx
@@ -61,7 +61,7 @@ export default function Page() {
         formData.append('splitHorizontal', splitHorizontal.toString());
         formData.append('splitVertical', splitVertical.toString());
 
-        return await axios.post('/api/v1/image-generator', formData, { data: formData }).then((result) => result.data as string[]);
+        return await axios.post('/image-generator/router', formData, { data: formData }).then((result) => result.data as string[]);
       }
       return null;
     },


### PR DESCRIPTION
…uter

The API endpoint path was incorrectly set to '/api/v1/image-generator', which caused the request to fail. This commit updates the path to 'image-generator/router' to ensure the request is routed correctly.