### PR TITLE
fix(image-generator): update API endpoint from '/router' to '/sorter'

### DIFF
--- a/app/[locale]/(main)/image-generator/router/page.tsx
+++ b/app/[locale]/(main)/image-generator/router/page.tsx
@@ -61,7 +61,7 @@ export default function Page() {
         formData.append('splitHorizontal', splitHorizontal.toString());
         formData.append('splitVertical', splitVertical.toString());
 
-        return await axios.post('/image-generator/router', formData, { data: formData }).then((result) => result.data as string[]);
+        return await axios.post('/image-generator/sorter', formData, { data: formData }).then((result) => result.data as string[]);
       }
       return null;
     },


### PR DESCRIPTION
The API endpoint was incorrectly pointing to '/image-generator/router'. This commit corrects it to '/image-generator/sorter' to ensure the image generation process functions as intended.