### PR TITLE
refactor(navbar): simplify NavbarLink component and remove redundant …

### DIFF
--- a/app/[locale]/(main)/medium-navigation-items.tsx
+++ b/app/[locale]/(main)/medium-navigation-items.tsx
@@ -111,12 +111,5 @@ export type PathElementProps = {
   };
 };
 export function PathElement({ segment }: PathElementProps) {
-  const { icon, name } = segment;
-
-  return (
-    <NavbarLink {...segment}>
-      {icon}
-      <NavbarVisible>{name}</NavbarVisible>
-    </NavbarLink>
-  );
+  return <NavbarLink {...segment} />;
 }

--- a/app/[locale]/(main)/navbar-link.tsx
+++ b/app/[locale]/(main)/navbar-link.tsx
@@ -3,6 +3,8 @@
 import { usePathname } from 'next/navigation';
 import React from 'react';
 
+import NavbarVisible from '@/app/navbar-visible';
+
 import InternalLink from '@/components/common/internal-link';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
@@ -11,34 +13,18 @@ import { useSession } from '@/context/session-context';
 import { Filter, cn, hasAccess } from '@/lib/utils';
 
 type Props = {
-  children: React.ReactNode;
+  icon: React.ReactNode;
+  name: React.ReactNode;
   path: string;
   regex: string[];
   filter?: Filter;
 };
-export default function NavbarLink({ children, path, regex, filter }: Props) {
+export default function NavbarLink({ name, icon, path, regex, filter }: Props) {
   const { session } = useSession();
-
-  if (filter) {
-    return hasAccess(session, filter) ? (
-      <NavbarLinkInternal path={path} regex={regex} filter={filter}>
-        {children}
-      </NavbarLinkInternal>
-    ) : undefined;
-  }
-
-  return (
-    <NavbarLinkInternal path={path} regex={regex} filter={filter}>
-      {children}
-    </NavbarLinkInternal>
-  );
-}
-
-function NavbarLinkInternal({ children, path, regex }: Props) {
   const { visible, setVisible } = useNavBar();
   const currentPath = usePathname();
 
-  return (
+  return hasAccess(session, filter) ? (
     <Tooltip>
       <TooltipTrigger>
         <InternalLink
@@ -51,10 +37,11 @@ function NavbarLinkInternal({ children, path, regex }: Props) {
           aria-label={path}
           onClick={() => setVisible(false)}
         >
-          {children}
+          {icon}
+          <NavbarVisible>{name}</NavbarVisible>
         </InternalLink>
       </TooltipTrigger>
-      {!visible && <TooltipContent>{children}</TooltipContent>}
+      {!visible && <TooltipContent>{name}</TooltipContent>}
     </Tooltip>
-  );
+  ) : undefined;
 }

--- a/app/[locale]/(main)/nested-path-element.tsx
+++ b/app/[locale]/(main)/nested-path-element.tsx
@@ -2,7 +2,6 @@ import { ReactNode } from 'react';
 
 import NavbarLink from '@/app/[locale]/(main)/navbar-link';
 import { NestedPathElementContainer } from '@/app/[locale]/(main)/nested-path-element-container';
-import NavbarVisible from '@/app/navbar-visible';
 
 import { Filter } from '@/lib/utils';
 
@@ -32,10 +31,7 @@ export default function NestedPathElement({ segment }: NestedPathElementProps) {
   return (
     <NestedPathElementContainer segment={segment}>
       {path.map((item) => (
-        <NavbarLink key={item.id} {...item}>
-          {item.icon}
-          <NavbarVisible>{item.name}</NavbarVisible>
-        </NavbarLink>
+        <NavbarLink key={item.id} {...item} />
       ))}
     </NestedPathElementContainer>
   );


### PR DESCRIPTION
…children

The NavbarLink component was refactored to directly accept `icon` and `name` props instead of using `children`. This change simplifies the component and removes redundant code in `PathElement` and `NestedPathElement`. The `NavbarVisible` component is now directly used within `NavbarLink`, improving maintainability and reducing complexity.