### PR TITLE
refactor(servers): migrate server components to client-side rendering

### DIFF
--- a/app/[locale]/(main)/servers/community-server.tsx
+++ b/app/[locale]/(main)/servers/community-server.tsx
@@ -1,16 +1,13 @@
-import ErrorScreen from '@/components/common/error-screen';
+'use client'
 import ServerCard from '@/components/server/server-card';
 
-import { serverApi } from '@/action/action';
-import { isError } from '@/lib/utils';
 import { getServers } from '@/query/server';
+import InfinitePage from '@/components/common/infinite-page';
+import { PaginationQuerySchema } from '@/query/search-query';
+import ServerCardSkeleton from '@/components/server/server-card-skeleton';
 
-export async function CommunityServer({ valid }: { valid: boolean }) {
-  const servers = await serverApi((axios) => getServers(axios, { valid, official: false, page: 0, size: 50 }));
-
-  if (isError(servers)) {
-    return <ErrorScreen error={servers} />;
-  }
-
-  return servers.map((server) => <ServerCard server={server} key={server.port} />);
+export default function CommunityServer() {
+    return <InfinitePage className='grid h-full w-full grid-cols-[repeat(auto-fill,minmax(min(350px,100%),1fr))] gap-2' queryKey={['community-server']} skeleton={{ 'item': <ServerCardSkeleton />, amount: 20 }} paramSchema={PaginationQuerySchema} queryFn={(axios, { size, page }) => getServers((axios), { official: true, page, size })}>
+        {(server) => <ServerCard server={server} key={server.port} />}
+    </InfinitePage>
 }

--- a/app/[locale]/(main)/servers/my-server.tsx
+++ b/app/[locale]/(main)/servers/my-server.tsx
@@ -1,16 +1,22 @@
-import ErrorScreen from '@/components/common/error-screen';
+'use client'
+
 import ServerCard from '@/components/server/server-card';
 
-import { serverApi } from '@/action/action';
-import { isError } from '@/lib/utils';
 import { getMeServers } from '@/query/user';
+import useClientQuery from '@/hooks/use-client-query';
+import ServersSkeleton from '@/app/[locale]/(main)/servers/servers-skeleton';
+import ErrorMessage from '@/components/common/error-message';
 
-export default async function MeServer() {
-  const servers = await serverApi((axios) => getMeServers(axios));
+export default function MeServer() {
+    const { data, isLoading, isError, error } = useClientQuery({ queryKey: ['me-server'], queryFn: (axios) => getMeServers(axios) });
 
-  if (isError(servers)) {
-    return <ErrorScreen error={servers} />;
-  }
+    if (isLoading) {
+        return <ServersSkeleton />
+    }
 
-  return servers.map((server) => <ServerCard server={server} key={server.port} />);
+    if (isError) {
+        return <ErrorMessage error={error} />
+    }
+
+    return data?.map((server) => <ServerCard server={server} key={server.port} />);
 }

--- a/app/[locale]/(main)/servers/official-server.tsx
+++ b/app/[locale]/(main)/servers/official-server.tsx
@@ -1,16 +1,13 @@
-import ErrorScreen from '@/components/common/error-screen';
+'use client'
 import ServerCard from '@/components/server/server-card';
 
-import { serverApi } from '@/action/action';
-import { isError } from '@/lib/utils';
 import { getServers } from '@/query/server';
+import InfinitePage from '@/components/common/infinite-page';
+import { PaginationQuerySchema } from '@/query/search-query';
+import ServerCardSkeleton from '@/components/server/server-card-skeleton';
 
-export default async function OfficialServer({ valid }: { valid: boolean }) {
-  const servers = await serverApi((axios) => getServers(axios, { valid, official: true, page: 0, size: 50 }));
-
-  if (isError(servers)) {
-    return <ErrorScreen error={servers} />;
-  }
-
-  return servers.map((server) => <ServerCard server={server} key={server.port} />);
+export default function OfficialServer() {
+    return <InfinitePage className='grid h-full w-full grid-cols-[repeat(auto-fill,minmax(min(350px,100%),1fr))] gap-2' queryKey={['offical-server']} skeleton={{ 'item': <ServerCardSkeleton />, amount: 20 }} paramSchema={PaginationQuerySchema} queryFn={(axios, { size, page }) => getServers((axios), { official: true, page, size })}>
+        {(server) => <ServerCard server={server} key={server.port} />}
+    </InfinitePage>
 }

--- a/app/[locale]/(main)/servers/page.footer.tsx
+++ b/app/[locale]/(main)/servers/page.footer.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import CreateServerDialog from "@/app/[locale]/(main)/servers/create-server-dialog";
+import InternalLink from "@/components/common/internal-link";
+import RequireLogin from "@/components/common/require-login";
+import Tran from "@/components/common/tran";
+import { useSession } from "@/context/session-context";
+import ProtectedElement from "@/layout/protected-element";
+
+export default function ServerFooter({ create }: { create?: boolean }) {
+    const { session } = useSession()
+
+    return (
+        <footer className="flex w-full justify-end gap-2">
+            <ProtectedElement session={session} filter={true} alt={<RequireLogin />}>
+                <InternalLink variant="button-secondary" href="/server-managers">
+                    <Tran text="server-manager" />
+                </InternalLink>
+                <CreateServerDialog defaultOpen={!!create} />
+            </ProtectedElement>
+        </footer>
+    );
+
+}

--- a/app/[locale]/(main)/servers/page.tsx
+++ b/app/[locale]/(main)/servers/page.tsx
@@ -2,138 +2,98 @@ import { Metadata } from 'next';
 import dynamic from 'next/dynamic';
 import React, { Suspense } from 'react';
 
-import { CommunityServer } from '@/app/[locale]/(main)/servers/community-server';
-import CreateServerDialog from '@/app/[locale]/(main)/servers/create-server-dialog';
 
-import InternalLink from '@/components/common/internal-link';
 import RequireLogin from '@/components/common/require-login';
 import ScrollContainer from '@/components/common/scroll-container';
 import Tran from '@/components/common/tran';
-import ServerCardSkeleton from '@/components/server/server-card-skeleton';
 import { ServerTabs, ServerTabsContent, ServerTabsList, ServerTabsTrigger } from '@/components/ui/server-tabs';
-import Skeletons from '@/components/ui/skeletons';
 
-import { getSession } from '@/action/action';
 import { Locale } from '@/i18n/config';
 import { getTranslation } from '@/i18n/server';
-import ProtectedElement from '@/layout/protected-element';
-import { formatTitle, generateAlternate, hasAccess } from '@/lib/utils';
+import { formatTitle, generateAlternate } from '@/lib/utils';
+import ServerFooter from '@/app/[locale]/(main)/servers/page.footer';
+import ClientProtectedElement from '@/layout/client-protected-element';
+import ServersSkeleton from '@/app/[locale]/(main)/servers/servers-skeleton';
+import OfficialServer from '@/app/[locale]/(main)/servers/official-server';
 
 const MeServer = dynamic(() => import('@/app/[locale]/(main)/servers/my-server'));
-const OfficialServer = dynamic(() => import('@/app/[locale]/(main)/servers/official-server'));
+const CommunityServer = dynamic(() => import('@/app/[locale]/(main)/servers/community-server'));
 
 export const experimental_ppr = true;
 
 type Props = {
-  params: Promise<{ locale: Locale }>;
-  searchParams: Promise<{ create?: boolean }>;
+	params: Promise<{ locale: Locale }>;
+	searchParams: Promise<{ create?: boolean }>;
 };
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { locale } = await params;
-  const { t } = await getTranslation(locale, ['common', 'meta']);
-  const title = t('server');
+	const { locale } = await params;
+	const { t } = await getTranslation(locale, ['common', 'meta']);
+	const title = t('server');
 
-  return {
-    title: formatTitle(title),
-    description: t('server-description'),
-    openGraph: {
-      title: formatTitle(title),
-      description: t('server-description'),
-    },
-    alternates: generateAlternate('/servers'),
-  };
+	return {
+		title: formatTitle(title),
+		description: t('server-description'),
+		openGraph: {
+			title: formatTitle(title),
+			description: t('server-description'),
+		},
+		alternates: generateAlternate('/servers'),
+	};
 }
 
 function LoginToCreateServer() {
-  return (
-    <div className="flex h-full w-full flex-col items-center justify-center gap-2">
-      <Tran text="server.login-to-create-server" />
-      <RequireLogin />
-    </div>
-  );
+	return (
+		<div className="flex h-full w-full flex-col items-center justify-center gap-2">
+			<Tran text="server.login-to-create-server" />
+			<RequireLogin />
+		</div>
+	);
 }
 
 export default async function Page({ searchParams }: Props) {
-  const { create } = await searchParams;
-  const session = await getSession();
-  const valid = !hasAccess(session, { authority: 'UPDATE_SERVER' });
+	const { create } = await searchParams;
 
-  return (
-    <div className="flex h-full flex-col overflow-hidden space-y-2 p-2">
-      <ServerTabs className="flex h-full w-full flex-col overflow-hidden" name="tab" value="official-server" values={['official-server', 'community-server', 'my-server']}>
-        <ServerTabsList className="w-full justify-start h-14 min-h-14">
-          <ServerTabsTrigger value="official-server">
-            <Tran text="server.official-server" />
-          </ServerTabsTrigger>
-          <ServerTabsTrigger value="community-server">
-            <Tran text="server.community-server" />
-          </ServerTabsTrigger>
-          <ServerTabsTrigger value="my-server">
-            <Tran text="server.my-server" />
-          </ServerTabsTrigger>
-        </ServerTabsList>
-        <ServerTabsContent className="overflow-hidden" value="official-server">
-          <Suspense fallback={<ServersSkeleton />}>
-            <ScrollContainer className="grid h-full w-full grid-cols-[repeat(auto-fill,minmax(min(350px,100%),1fr))] gap-2">
-              <OfficialServer valid={valid} />
-            </ScrollContainer>
-          </Suspense>
-        </ServerTabsContent>
-        <ServerTabsContent className="overflow-hidden" value="community-server">
-          <Suspense fallback={<ServersSkeleton />}>
-            <ScrollContainer className="grid h-full w-full grid-cols-[repeat(auto-fill,minmax(min(350px,100%),1fr))] gap-2">
-              <CommunityServer valid={valid} />
-            </ScrollContainer>
-          </Suspense>
-        </ServerTabsContent>
-        <ServerTabsContent className="overflow-hidden" value="my-server">
-          <Suspense fallback={<ServersSkeleton />}>
-            <MyServer />
-          </Suspense>
-        </ServerTabsContent>
-      </ServerTabs>
-      <Suspense>
-        <Footer create={create} />
-      </Suspense>
-    </div>
-  );
-}
-
-async function Footer({ create }: { create?: boolean }) {
-  const session = await getSession();
-
-  return (
-    <footer className="flex w-full justify-end gap-2">
-      <ProtectedElement session={session} filter={true} alt={<RequireLogin />}>
-        <InternalLink variant="button-secondary" href="/server-managers">
-          <Tran text="server-manager" />
-        </InternalLink>
-        <CreateServerDialog defaultOpen={!!create} />
-      </ProtectedElement>
-    </footer>
-  );
-}
-
-async function ServersSkeleton() {
-  return (
-    <div className="grid w-full grid-cols-[repeat(auto-fill,minmax(min(350px,100%),1fr))] gap-2">
-      <Skeletons number={20}>
-        <ServerCardSkeleton />
-      </Skeletons>
-    </div>
-  );
-}
-
-async function MyServer() {
-  const session = await getSession();
-
-  return (
-    <Suspense fallback={<ServersSkeleton />}>
-      <ProtectedElement session={session} filter={true} alt={<LoginToCreateServer />}>
-        <ScrollContainer className="grid h-full w-full grid-cols-[repeat(auto-fill,minmax(min(350px,100%),1fr))] gap-2">
-          <MeServer />
-        </ScrollContainer>
-      </ProtectedElement>
-    </Suspense>
-  );
+	return (
+		<div className="flex h-full flex-col overflow-hidden space-y-2 p-2">
+			<ServerTabs className="flex h-full w-full flex-col overflow-hidden" name="tab" value="official-server" values={['official-server', 'community-server', 'my-server']}>
+				<ServerTabsList className="w-full justify-start h-14 min-h-14">
+					<ServerTabsTrigger value="official-server">
+						<Tran text="server.official-server" />
+					</ServerTabsTrigger>
+					<ServerTabsTrigger value="community-server">
+						<Tran text="server.community-server" />
+					</ServerTabsTrigger>
+					<ServerTabsTrigger value="my-server">
+						<Tran text="server.my-server" />
+					</ServerTabsTrigger>
+				</ServerTabsList>
+				<ServerTabsContent className="overflow-hidden" value="official-server">
+					<ScrollContainer >
+						<Suspense fallback={<ServersSkeleton />}>
+							<OfficialServer />
+						</Suspense>
+					</ScrollContainer>
+				</ServerTabsContent>
+				<ServerTabsContent className="overflow-hidden" value="community-server">
+					<ScrollContainer>
+						<Suspense fallback={<ServersSkeleton />}>
+							<CommunityServer />
+						</Suspense>
+					</ScrollContainer>
+				</ServerTabsContent>
+				<ServerTabsContent className="overflow-hidden" value="my-server">
+					<ClientProtectedElement filter alt={<LoginToCreateServer />}>
+						<ScrollContainer className="grid h-full w-full grid-cols-[repeat(auto-fill,minmax(min(350px,100%),1fr))] gap-2">
+							<Suspense fallback={<ServersSkeleton />}>
+								<MeServer />
+							</Suspense>
+						</ScrollContainer>
+					</ClientProtectedElement>
+				</ServerTabsContent>
+			</ServerTabs>
+			<Suspense>
+				<ServerFooter create={create} />
+			</Suspense>
+		</div>
+	);
 }

--- a/app/[locale]/(main)/servers/servers-skeleton.tsx
+++ b/app/[locale]/(main)/servers/servers-skeleton.tsx
@@ -1,0 +1,10 @@
+import ServerCardSkeleton from "@/components/server/server-card-skeleton";
+import Skeletons from "@/components/ui/skeletons";
+
+export default function ServersSkeleton() {
+    return (
+        <Skeletons number={20}>
+            <ServerCardSkeleton />
+        </Skeletons>
+    );
+}

--- a/components/server/server-card.tsx
+++ b/components/server/server-card.tsx
@@ -14,7 +14,7 @@ type MyServerInstancesCardProps = {
   server: ServerDto;
 };
 
-export default async function ServerCard({ server: { id, name, players, port, status, mapName, mode, address } }: MyServerInstancesCardProps) {
+export default function ServerCard({ server: { id, name, players, port, status, mapName, mode, address } }: MyServerInstancesCardProps) {
   return (
     <InternalLink className="flex flex-1 cursor-pointer flex-col gap-2 rounded-md bg-card p-4 h-60 relative" href={`/servers/${id}`}>
       <Suspense>

--- a/layout/client-protected-element.tsx
+++ b/layout/client-protected-element.tsx
@@ -1,0 +1,13 @@
+'use client'
+import { ComponentProps } from 'react';
+
+import ProtectedElement from '@/layout/protected-element';
+import { useSession } from '@/context/session-context';
+
+type Props = Omit<ComponentProps<typeof ProtectedElement>, 'session'>
+
+export default function ClientProtectedElement({ children, ...props }: Props) {
+    const { session } = useSession()
+
+    return <ProtectedElement session={session} {...props}>{children}</ProtectedElement>
+}

--- a/query/server.ts
+++ b/query/server.ts
@@ -115,7 +115,7 @@ export async function getServerSetting(axios: AxiosInstance, { id }: IdSearchPar
   return result.data;
 }
 
-export async function getServers(axios: AxiosInstance, params: { official?: boolean; valid?: boolean } & PaginationQuery): Promise<ServerDto[]> {
+export async function getServers(axios: AxiosInstance, params: { official?: boolean } & PaginationQuery): Promise<ServerDto[]> {
   const result = await axios.get(`/servers`, { params });
 
   return result.data;


### PR DESCRIPTION
Refactor server-related components to use client-side rendering for better performance and user experience. This includes moving `ServerCard`, `OfficialServer`, `CommunityServer`, and `MeServer` to client components, introducing `ClientProtectedElement`, and adding skeleton loading states. The changes also simplify the server page structure and improve code maintainability.