### PR TITLE
fix(community-server): set official parameter to false in queryFn

### DIFF
--- a/app/[locale]/(main)/servers/community-server.tsx
+++ b/app/[locale]/(main)/servers/community-server.tsx
@@ -7,7 +7,7 @@ import { PaginationQuerySchema } from '@/query/search-query';
 import ServerCardSkeleton from '@/components/server/server-card-skeleton';
 
 export default function CommunityServer() {
-    return <InfinitePage className='grid h-full w-full grid-cols-[repeat(auto-fill,minmax(min(350px,100%),1fr))] gap-2' queryKey={['community-server']} skeleton={{ 'item': <ServerCardSkeleton />, amount: 20 }} paramSchema={PaginationQuerySchema} queryFn={(axios, { size, page }) => getServers((axios), { official: true, page, size })}>
+    return <InfinitePage className='grid h-full w-full grid-cols-[repeat(auto-fill,minmax(min(350px,100%),1fr))] gap-2' queryKey={['community-server']} skeleton={{ 'item': <ServerCardSkeleton />, amount: 20 }} paramSchema={PaginationQuerySchema} queryFn={(axios, { size, page }) => getServers((axios), { official: false, page, size })}>
         {(server) => <ServerCard server={server} key={server.port} />}
     </InfinitePage>
 }


### PR DESCRIPTION
The official parameter in the queryFn was incorrectly set to true, causing the community server to only display official servers. This change ensures that all community servers are displayed as intended.