### PR TITLE
feat(logic-editor): add toggleable minimap and live code panel

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,11 @@
 {
-  "extends": ["next", "next/core-web-vitals", "eslint:recommended", "plugin:@typescript-eslint/eslint-recommended", "plugin:@typescript-eslint/recommended"],
+  "extends": [
+    "next",
+    "next/core-web-vitals",
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
   "rules": {
     "@typescript-eslint/no-unused-expressions": "error",
     "@typescript-eslint/no-unused-vars": [
@@ -11,7 +17,12 @@
       }
     ],
     "@typescript-eslint/unified-signatures": "warn",
-    "@typescript-eslint/no-explicit-any": "off"
+    "@typescript-eslint/no-explicit-any": "off",
+    "no-mixed-spaces-and-tabs": "off"
   },
-  "ignorePatterns": ["*.js", "node_modules", ".next"]
+  "ignorePatterns": [
+    "*.js",
+    "node_modules",
+    ".next"
+  ]
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -12,7 +12,7 @@
     ],
     "importOrderSeparation": true,
     "importOrderSortSpecifiers": true,
-    "printWidth": 250,
+    "printWidth": 200,
     "tabWidth": 2,
-    "useTabs": true,
+    "useTabs": true
 }

--- a/app/[locale]/logic/instruction.node.tsx
+++ b/app/[locale]/logic/instruction.node.tsx
@@ -1,4 +1,4 @@
-
+import { instructionNodes, useLogicEditor } from '@/app/[locale]/logic/logic-editor-context';
 import { InferStateType, ItemsType, NodeData, NodeItem } from '@/app/[locale]/logic/node';
 import { OutputHandle } from '@/app/[locale]/logic/output-handle';
 
@@ -7,110 +7,92 @@ import ComboBox from '@/components/common/combo-box';
 import { cn } from '@/lib/utils';
 
 import { Handle, Node, Position } from '@xyflow/react';
-import { instructionNodes, useLogicEditor } from '@/app/[locale]/logic/logic-editor-context';
-
 
 export type InstructionNodeData<T extends (keyof typeof instructionNodes)[number] = (keyof typeof instructionNodes)[number]> = {
-  data: { type: T; index?: number; node: NodeData; state: InferStateType<(typeof instructionNodes)[T]['items']> };
-  isConnectable?: boolean;
-  type: 'instruction';
-  id: string
+	data: { type: T; index?: number; node: NodeData; state: InferStateType<(typeof instructionNodes)[T]['items']> };
+	isConnectable?: boolean;
+	type: 'instruction';
+	id: string;
 };
 
 export type InstructionNode = Omit<Node, 'data' | 'type'> & InstructionNodeData;
 
 export default function InstructionNodeComponent({ id, data }: InstructionNodeData) {
-  const { state, node } = data
-  const { label, color, inputs, outputs, items, condition } = node;
+	const { state, node } = data;
+	const { label, color, inputs, outputs, items, condition } = node;
 
-  const { setNodeState } = useLogicEditor()
+	const filterdItems = items.filter((item) => 'name' in item && condition?.[item.name]?.(state));
 
-  return (
-    <div
-      className={cn('p-1.5 rounded-sm text-white w-[220px] min-h-[80px] sm:w-[330px] md:w-[440px] lg:[w-550px]', {
-        'w-fit min-h-0 sm:w-fit md:w-fit lg:w-fit px-6': items.length === 0,
-      })}
-      style={{ backgroundColor: color }}
-    >
-      {Array(inputs)
-        .fill(1)
-        .map((_, i) => (
-          <Handle style={{ marginLeft: 20 * i - ((inputs - 1) / 2) * 20 + 'px' }} key={i} type={'target'} position={Position.Top} isConnectable={true} />
-        ))}
-      {outputs.map((output, i) => (
-        <OutputHandle id={`${id}-source-handle-${i}`} style={{ marginLeft: 20 * i - ((outputs.length - 1) / 2) * 20 + 'px' }} label={output.label} key={i} type={'source'} position={Position.Bottom} />
-      ))}
-      <div
-        className={cn('flex justify-between text-sm font-bold', {
-          'w-full h-full items-center justify-center m-auto text-xl align-middle': items.length === 0,
-        })}
-      >
-        <span>{label}</span>
-        <span>{data.index}</span>
-      </div>
-      {items.length > 0 && (
-        <div className="bg-black p-2 rounded-sm flex gap-1 items-end jus flex-wrap">
-          {items.map((item, i) => (
-            <NodeItemComponent key={i} color={color} data={item} state={state} setState={(state) => setNodeState(id, (prev) => ({ ...prev, ...state }))} condition={'name' in item ? condition?.[item.name] : undefined} />
-          ))}
-        </div>
-      )}
-    </div>
-  );
+	return (
+		<div
+			className={cn('p-1.5 rounded-sm text-white w-[220px] min-h-[80px] sm:w-[330px] md:w-[440px] lg:[w-550px]', {
+				'w-fit min-h-0 sm:w-fit md:w-fit lg:w-fit px-6': items.length === 0,
+			})}
+			style={{ backgroundColor: color }}
+		>
+			{Array(inputs)
+				.fill(1)
+				.map((_, i) => (
+					<Handle style={{ marginLeft: 20 * i - ((inputs - 1) / 2) * 20 + 'px' }} key={i} type={'target'} position={Position.Top} isConnectable={true} />
+				))}
+			{outputs.map((output, i) => (
+				<OutputHandle id={`${id}-source-handle-${i}`} style={{ marginLeft: 20 * i - ((outputs.length - 1) / 2) * 20 + 'px' }} label={output.label} key={i} type={'source'} position={Position.Bottom} />
+			))}
+			<div
+				className={cn('flex justify-between text-sm font-bold', {
+					'w-full h-full items-center justify-center m-auto text-xl align-middle': items.length === 0,
+				})}
+			>
+				<span>{label}</span>
+				<span>{data.index}</span>
+			</div>
+			{items.length > 0 && (
+				<div className="bg-black p-2 rounded-sm flex gap-1 items-end jus flex-wrap">
+					{filterdItems.map((item, i) => (
+						<NodeItemComponent key={i} nodeId={id} color={color} data={item} state={state} />
+					))}
+				</div>
+			)}
+		</div>
+	);
 }
 
-function NodeItemComponent({
-  color,
-  data,
-  condition,
-  state,
-  setState,
-}: {
-  color: string;
-  state: InferStateType<ItemsType>;
-  setState: (data: InferStateType<ItemsType>) => void;
-  data: NodeItem;
-  condition?: (data: InferStateType<ItemsType>) => boolean;
-}) {
-  const canRender = condition ? condition(state) : true;
+function NodeItemComponent({ nodeId, color, data, state }: { nodeId: string; color: string; state: InferStateType<ItemsType>; data: NodeItem }) {
+	const { setNodeState } = useLogicEditor();
 
-  if (!canRender) {
-    return <></>;
-  }
+	if (data.type === 'input') {
+		return (
+			<div className="flex gap-1 w-40">
+				{data.label && <span className="border-transparent border-b-[3px]">{data.label}</span>}
+				<input
+					className="bg-transparent border-b-[3px] px-2 hover min-w-20 max-w-40 sm:max-w-80 focus:outline-none" //
+					style={{ borderColor: color }}
+					type="text"
+					value={state[data.name] ?? data.value ?? ''}
+					onChange={(e) => setNodeState(nodeId, (prev) => ({ ...prev, [data.name]: e.target.value }))}
+				/>
+			</div>
+		);
+	}
 
-  if (data.type === 'input') {
-    return (
-      <div className="flex gap-1 w-40">
-        {data.label && <span className="border-transparent border-b-[3px]">{data.label}</span>}
-        <input
-          className="bg-transparent border-b-[3px] px-2 hover min-w-20 max-w-40 sm:max-w-80 focus:outline-none" //
-          style={{ borderColor: color }}
-          type="text"
-          value={state[data.name] ?? data.value ?? ''}
-          onChange={(e) => setState({ ...state, [data.name]: e.target.value })}
-        />
-      </div>
-    );
-  }
+	if (data.type === 'option') {
+		return (
+			<div className="bg-transparent border-b-[3px] flex items-end" style={{ borderColor: color }}>
+				<ComboBox
+					className="bg-transparent px-2 py-0 text-center w-fit font-bold border-transparent items-end justify-end"
+					value={{ value: state[data.name], label: state[data.name].toString() }}
+					values={data.options.map((option) => ({ value: option, label: option.toString() }))}
+					onChange={(value) => {
+						if (value) setNodeState(nodeId, (prev) => ({ ...prev, [data.name]: value }));
+					}}
+					searchBar={false}
+					chevron={false}
+				/>
+			</div>
+		);
+	}
 
-  if (data.type === 'option') {
-    return (
-      <div className="bg-transparent border-b-[3px] flex items-end" style={{ borderColor: color }}>
-        <ComboBox
-          className="bg-transparent px-2 py-0 text-center w-fit font-bold border-transparent items-end justify-end"
-          value={{ value: state[data.name], label: state[data.name].toString() }}
-          values={data.options.map((option) => ({ value: option, label: option.toString() }))}
-          onChange={(value) => {
-            if (value) setState({ ...state, [data.name]: value });
-          }}
-          searchBar={false}
-          chevron={false}
-        />
-      </div>
-    );
-  }
-
-  if (data.type === 'label') {
-    return <span className="border-transparent border-b-[3px]">{data.value}</span>;
-  }
+	if (data.type === 'label') {
+		return <span className="border-transparent border-b-[3px]">{data.value}</span>;
+	}
 }

--- a/app/[locale]/logic/node.tsx
+++ b/app/[locale]/logic/node.tsx
@@ -27,7 +27,7 @@ type LabelItem<T extends string = string> = {
 
 type InputItemAccept = 'number' | 'string' | 'boolean' | 'variable';
 
-type InputItem<T extends string = string, N extends string = string> = {
+export type InputItem<T extends string = string, N extends string = string> = {
 	type: 'input';
 	label?: string;
 	name: N;
@@ -36,7 +36,7 @@ type InputItem<T extends string = string, N extends string = string> = {
 	produce?: boolean;
 };
 
-type OptionItem<T extends string = string, N extends string = string> = {
+export type OptionItem<T extends string = string, N extends string = string> = {
 	type: 'option';
 	name: N;
 	options: T[];

--- a/app/[locale]/logic/page.tsx
+++ b/app/[locale]/logic/page.tsx
@@ -2,10 +2,9 @@
 
 import React from 'react';
 
-import LiveCodePanel from '@/app/[locale]/logic/live-code-panel';
 import { LogicEditorProvider } from '@/app/[locale]/logic/logic-editor-context';
 
-import { Background, Controls, MiniMap, ReactFlowProvider } from '@xyflow/react';
+import { Background, ReactFlowProvider } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 
 import './style.css';
@@ -23,8 +22,6 @@ function Flow() {
 		<div className="flex flex-col h-full overflow-hidden">
 			<ReactFlowProvider>
 				<LogicEditorProvider>
-					<LiveCodePanel />
-					<MiniMap />
 					<Background />
 				</LogicEditorProvider>
 			</ReactFlowProvider>

--- a/app/[locale]/logic/toolbar.tsx
+++ b/app/[locale]/logic/toolbar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Eraser, PlusCircleIcon, RedoIcon, UndoIcon, ZoomInIcon, ZoomOutIcon } from 'lucide-react';
+import { Eraser, MapIcon, PlusCircleIcon, RedoIcon, UndoIcon, ZoomInIcon, ZoomOutIcon } from 'lucide-react';
 import { ReactNode } from 'react';
 
 import { nodeOptions, useLogicEditor } from '@/app/[locale]/logic/logic-editor-context';
@@ -8,6 +8,7 @@ import LogicEditorNavBar from '@/app/[locale]/logic/logic-editor-nav-bar';
 
 import { CatchError } from '@/components/common/catch-error';
 import { Hidden } from '@/components/common/hidden';
+import { LivePanelIcon } from '@/components/common/icons';
 import Shortcut from '@/components/common/shortcut';
 import Tran from '@/components/common/tran';
 import { Button } from '@/components/ui/button';
@@ -32,7 +33,7 @@ const tabs: TabType[] = [
 	},
 	{
 		label: 'logic.view',
-		items: [<ZoomIn key={0} />, <ZoomInOut key={1} />],
+		items: [<ZoomIn key={0} />, <ZoomInOut key={1} />, <MiniMapButton key={2} />, <LiveCodeButton key={3} />],
 	},
 	{
 		label: 'logic.help',
@@ -57,6 +58,36 @@ function ZoomInOut() {
 		<Button onClick={() => zoomOut({ duration: 300 })} variant={'toogle'}>
 			<ZoomOutIcon className="size-4" />
 			<Tran asChild text="logic.zoom-out" />
+		</Button>
+	);
+}
+
+function MiniMapButton() {
+	const {
+		showMiniMap,
+		actions: { setShowMiniMap },
+	} = useLogicEditor();
+
+	return (
+		<Button onClick={() => setShowMiniMap(!showMiniMap)} variant={showMiniMap ? 'toogled' : 'toogle'}>
+			<MapIcon className="size-4" />
+			<Tran asChild text="logic.show-minimap" />
+			<Shortcut shortcut={['ctrl', 'm']} />
+		</Button>
+	);
+}
+
+function LiveCodeButton() {
+	const {
+		showLiveCode,
+		actions: { setShowLiveCode },
+	} = useLogicEditor();
+
+	return (
+		<Button onClick={() => setShowLiveCode(!showLiveCode)} variant={showLiveCode ? 'toogled' : 'toogle'}>
+			<LivePanelIcon className="size-4" />
+			<Tran asChild text="logic.show-live-code" />
+			<Shortcut shortcut={['ctrl', 'l']} />
 		</Button>
 	);
 }
@@ -122,7 +153,9 @@ function UndoButton() {
 function ShortcutHandler() {
 	const {
 		isDeleteOnClick,
-		actions: { undo, redo, toggleDeleteOnClick, setShowAddNodeDialog },
+		showLiveCode,
+		showMiniMap,
+		actions: { undo, redo, toggleDeleteOnClick, setShowAddNodeDialog, setShowMiniMap, setShowLiveCode },
 	} = useLogicEditor();
 
 	useShortcut(['ctrl', 'e'], () => {
@@ -150,6 +183,14 @@ function ShortcutHandler() {
 		toast(<Tran text="saved" />);
 	});
 
+	useShortcut(['ctrl', 'l'], () => {
+		setShowLiveCode(!showLiveCode);
+	});
+
+	useShortcut(['ctrl', 'm'], () => {
+		setShowMiniMap(!showMiniMap);
+	});
+
 	return <></>;
 }
 
@@ -164,7 +205,7 @@ export default function ToolBar() {
 						<PopoverTrigger className="hover:bg-card text-muted-foreground hover:text-foreground p-2 py-1 rounded-sm capitalize">
 							<Tran asChild text={tab.label} />
 						</PopoverTrigger>
-						<PopoverContent className="p-2 m-2 bg-card grid capitalize">
+						<PopoverContent className="p-1 mx-2 my-4 bg-card grid capitalize space-y-1">
 							{tab.items.map((item, index) => (
 								<PopoverClose key={index} asChild>
 									{item}

--- a/components/common/catch-error.tsx
+++ b/components/common/catch-error.tsx
@@ -1,38 +1,49 @@
-import React from "react";
-import ErrorMessage from "./error-message";
+import React from 'react';
+
+import { getLoggedErrorMessage } from '@/lib/utils';
+import { reportError } from '@/query/api';
+import axiosInstance from '@/query/config/config';
+
+import * as Sentry from '@sentry/nextjs';
+
+import ErrorMessage from './error-message';
 
 interface Props {
-    children: React.ReactNode;
+	children: React.ReactNode;
 }
 
-type State = {
-    hasError: false;
-    error?: Error;
-} | {
-    hasError: true;
-    error: Error;
-}
+type State =
+	| {
+			hasError: false;
+			error?: Error;
+	  }
+	| {
+			hasError: true;
+			error: Error;
+	  };
 
 export class CatchError extends React.Component<Props, State> {
-    constructor(props: Props) {
-        super(props);
-        this.state = { hasError: false };
-    }
+	constructor(props: Props) {
+		super(props);
+		this.state = { hasError: false };
+	}
 
-    static getDerivedStateFromError(error: Error): State {
-        return { hasError: true, error };
-    }
+	static getDerivedStateFromError(error: Error): State {
+		return { hasError: true, error };
+	}
 
-    componwentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
-        console.log(error);
-        console.log(errorInfo);
-        this.setState({ error });
-    }
+	componwentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+		console.log(error);
+		console.log(errorInfo);
+		this.setState({ error });
+		reportError(axiosInstance, getLoggedErrorMessage(error as any));
+		Sentry.captureException(error);
+	}
 
-    render() {
-        if (this.state.hasError) {
-            return <ErrorMessage error={this.state.error} />;
-        }
-        return this.props.children;
-    }
+	render() {
+		if (this.state.hasError) {
+			return <ErrorMessage error={this.state.error} />;
+		}
+		return this.props.children;
+	}
 }


### PR DESCRIPTION
Introduce toggleable minimap and live code panel features in the logic editor. These features can be enabled/disabled via toolbar buttons or shortcuts (Ctrl+M for minimap, Ctrl+L for live code panel). The visibility state is persisted in local storage. Additionally, refactor the instruction node component to improve maintainability and fix minor styling issues.