### PR TITLE
fix(logic): handle undefined condition in instruction node filtering

### DIFF
--- a/app/[locale]/logic/instruction.node.tsx
+++ b/app/[locale]/logic/instruction.node.tsx
@@ -21,7 +21,7 @@ export default function InstructionNodeComponent({ id, data }: InstructionNodeDa
 	const { state, node } = data;
 	const { label, color, inputs, outputs, items, condition } = node;
 
-	const filterdItems = items.filter((item) => 'name' in item && condition?.[item.name]?.(state));
+	const filterdItems = items.filter((item) => 'name' in item && (!condition || !condition?.[item.name] || condition?.[item.name]?.(state)));
 
 	return (
 		<div

--- a/app/[locale]/logic/logic-editor-context.tsx
+++ b/app/[locale]/logic/logic-editor-context.tsx
@@ -9,13 +9,13 @@ import ToolBar from '@/app/[locale]/logic/toolbar';
 import { getHelperLines } from '@/app/[locale]/logic/utils';
 
 import { CatchError } from '@/components/common/catch-error';
-import Hydrated from '@/components/common/hydrated';
 import Tran from '@/components/common/tran';
 import { toast } from '@/components/ui/sonner';
 
 import { groupBy, uuid } from '@/lib/utils';
 
 import { Edge, EdgeChange, MiniMap, NodeChange, ProOptions, ReactFlow, addEdge, applyEdgeChanges, applyNodeChanges, useReactFlow } from '@xyflow/react';
+import Hydrated from '@/components/common/hydrated';
 
 export const nodeTypes = {
 	instruction: InstructionNodeComponent,
@@ -927,8 +927,9 @@ export function LogicEditorProvider({ children }: { children: React.ReactNode })
 				>
 					{children}
 					<Hydrated>
-						{showLiveCode && <LiveCodePanel />}
-						{showMiniMap && <MiniMap />}
+
+					{showLiveCode && <LiveCodePanel />}
+					{showMiniMap && <MiniMap />}
 					</Hydrated>
 					<HelperLines horizontal={helperLineHorizontal} vertical={helperLineVertical} />
 				</ReactFlow>

--- a/app/[locale]/logic/logic-editor-context.tsx
+++ b/app/[locale]/logic/logic-editor-context.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { createContext, useCallback, useContext, useMemo, useState } from 'react';
 import { useLocalStorage } from 'usehooks-ts';
 
@@ -5,17 +7,18 @@ import HelperLines from '@/app/[locale]/logic/helper-lines';
 import InstructionNodeComponent, { InstructionNode } from '@/app/[locale]/logic/instruction.node';
 import LiveCodePanel from '@/app/[locale]/logic/live-code-panel';
 import { InferStateType, InputItem, ItemsType, NodeData } from '@/app/[locale]/logic/node';
+import SideBar from '@/app/[locale]/logic/sidebar';
 import ToolBar from '@/app/[locale]/logic/toolbar';
 import { getHelperLines } from '@/app/[locale]/logic/utils';
 
 import { CatchError } from '@/components/common/catch-error';
+import Hydrated from '@/components/common/hydrated';
 import Tran from '@/components/common/tran';
 import { toast } from '@/components/ui/sonner';
 
 import { groupBy, uuid } from '@/lib/utils';
 
 import { Edge, EdgeChange, MiniMap, NodeChange, ProOptions, ReactFlow, addEdge, applyEdgeChanges, applyNodeChanges, useReactFlow } from '@xyflow/react';
-import Hydrated from '@/components/common/hydrated';
 
 export const nodeTypes = {
 	instruction: InstructionNodeComponent,
@@ -906,34 +909,36 @@ export function LogicEditorProvider({ children }: { children: React.ReactNode })
 				actions,
 			}}
 		>
-			<ToolBar />
-			<CatchError>
-				<ReactFlow
-					nodes={nodes}
-					edges={edges}
-					onNodesChange={onNodeChange}
-					onEdgesChange={onEdgeChange}
-					onConnect={onEdgeConnect}
-					onNodesDelete={onNodesDelete}
-					onEdgesDelete={onEdgesDelete}
-					nodeTypes={nodeTypes}
-					onNodeClick={onNodeClick}
-					onEdgeClick={onEdgeClick}
-					onNodeContextMenu={onNodeContextMenu}
-					onEdgeContextMenu={onEdgeContextMenu}
-					onNodeDragStop={onNodeDragStop}
-					proOptions={proOptions}
-					fitView
-				>
-					{children}
-					<Hydrated>
-
-					{showLiveCode && <LiveCodePanel />}
-					{showMiniMap && <MiniMap />}
-					</Hydrated>
-					<HelperLines horizontal={helperLineHorizontal} vertical={helperLineVertical} />
-				</ReactFlow>
-			</CatchError>
+			<SideBar />
+			<div className="grid grid-rows-[auto_1fr]">
+				<ToolBar />
+				<CatchError>
+					<ReactFlow
+						nodes={nodes}
+						edges={edges}
+						onNodesChange={onNodeChange}
+						onEdgesChange={onEdgeChange}
+						onConnect={onEdgeConnect}
+						onNodesDelete={onNodesDelete}
+						onEdgesDelete={onEdgesDelete}
+						nodeTypes={nodeTypes}
+						onNodeClick={onNodeClick}
+						onEdgeClick={onEdgeClick}
+						onNodeContextMenu={onNodeContextMenu}
+						onEdgeContextMenu={onEdgeContextMenu}
+						onNodeDragStop={onNodeDragStop}
+						proOptions={proOptions}
+						fitView
+					>
+						{children}
+						<Hydrated>
+							{showLiveCode && <LiveCodePanel />}
+							{showMiniMap && <MiniMap />}
+						</Hydrated>
+						<HelperLines horizontal={helperLineHorizontal} vertical={helperLineVertical} />
+					</ReactFlow>
+				</CatchError>
+			</div>
 		</LogicEditorContext.Provider>
 	);
 }

--- a/app/[locale]/logic/page.tsx
+++ b/app/[locale]/logic/page.tsx
@@ -1,14 +1,38 @@
-'use client';
-
+import { Metadata } from 'next';
 import React from 'react';
 
 import { LogicEditorProvider } from '@/app/[locale]/logic/logic-editor-context';
+
+import Tran from '@/components/common/tran';
+
+import { Locale } from '@/i18n/config';
+import { getTranslation } from '@/i18n/server';
+import { formatTitle, generateAlternate } from '@/lib/utils';
 
 import { Background, ReactFlowProvider } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 
 import './style.css';
 
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+	const { locale } = await params;
+	const { t } = await getTranslation(locale, ['common', 'meta']);
+	const title = t('logic');
+
+	return {
+		title: formatTitle(title),
+		description: t('logic-description'),
+		openGraph: {
+			title: formatTitle(title),
+			description: t('logic-description'),
+		},
+		alternates: generateAlternate('/logic'),
+	};
+}
+
+type Props = {
+	params: Promise<{ locale: Locale }>;
+};
 export default function Page() {
 	return (
 		<ReactFlowProvider>
@@ -19,12 +43,17 @@ export default function Page() {
 
 function Flow() {
 	return (
-		<div className="flex flex-col h-full overflow-hidden">
-			<ReactFlowProvider>
-				<LogicEditorProvider>
-					<Background />
-				</LogicEditorProvider>
-			</ReactFlowProvider>
-		</div>
+		<>
+			<div className="hidden grid-cols-[auto_1fr] h-full sm:grid">
+				<ReactFlowProvider>
+					<LogicEditorProvider>
+						<Background />
+					</LogicEditorProvider>
+				</ReactFlowProvider>
+			</div>
+			<span className="sm:hidden">
+				<Tran text="logic.require-bigger-device-screen" />
+			</span>
+		</>
 	);
 }

--- a/app/[locale]/logic/page.tsx
+++ b/app/[locale]/logic/page.tsx
@@ -51,7 +51,7 @@ function Flow() {
 					</LogicEditorProvider>
 				</ReactFlowProvider>
 			</div>
-			<span className="sm:hidden">
+			<span className="sm:hidden flex h-full w-full items-center justify-center font-bold m-auto">
 				<Tran text="logic.require-bigger-device-screen" />
 			</span>
 		</>

--- a/app/[locale]/logic/sidebar.tsx
+++ b/app/[locale]/logic/sidebar.tsx
@@ -1,11 +1,45 @@
 'use client';
 
+import { DownloadIcon, FileIcon, FolderIcon, LayoutGrid } from 'lucide-react';
+import { ReactNode } from 'react';
+
 import LogicEditorNavBar from '@/app/[locale]/logic/logic-editor-nav-bar';
+
+import { SearchIcon } from '@/components/common/icons';
+
+type TabType = {
+	icon: ReactNode;
+	item: ReactNode;
+};
+
+const tabs: TabType[] = [
+	{
+		icon: <FileIcon />,
+		item: <div></div>,
+	},
+	{
+		icon: <SearchIcon />,
+		item: <div></div>,
+	},
+	{
+		icon: <FolderIcon />,
+		item: <div></div>,
+	},
+	{
+		icon: <LayoutGrid />,
+		item: <div></div>,
+	},
+];
 
 export default function SideBar() {
 	return (
-		<div className="min-w-nav h-full flex items-center flex-col p-1 bg-card border-r">
+		<div className="min-w-nav h-full flex items-center flex-col p-1 bg-card border-r gap-2">
 			<LogicEditorNavBar />
+			{tabs.map((tab, index) => (
+				<div className="cursor-pointer p-2 rounded-md hover:bg-secondary" key={index}>
+					{tab.icon}
+				</div>
+			))}
 		</div>
 	);
 }

--- a/app/[locale]/logic/sidebar.tsx
+++ b/app/[locale]/logic/sidebar.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import LogicEditorNavBar from '@/app/[locale]/logic/logic-editor-nav-bar';
+
+export default function SideBar() {
+	return (
+		<div className="min-w-nav h-full flex items-center flex-col p-1 bg-card border-r">
+			<LogicEditorNavBar />
+		</div>
+	);
+}

--- a/app/[locale]/logic/toolbar.tsx
+++ b/app/[locale]/logic/toolbar.tsx
@@ -4,7 +4,6 @@ import { Eraser, MapIcon, PlusCircleIcon, RedoIcon, UndoIcon, ZoomInIcon, ZoomOu
 import { ReactNode } from 'react';
 
 import { nodeOptions, useLogicEditor } from '@/app/[locale]/logic/logic-editor-context';
-import LogicEditorNavBar from '@/app/[locale]/logic/logic-editor-nav-bar';
 
 import { CatchError } from '@/components/common/catch-error';
 import { Hidden } from '@/components/common/hidden';
@@ -40,6 +39,74 @@ const tabs: TabType[] = [
 		items: [],
 	},
 ];
+
+export default function ToolBar() {
+	return (
+		<div className="min-h-nav bg-card border-b overflow-x-auto p-1 flex items-center w-full">
+			<CatchError>
+				<ShortcutHandler />
+				{tabs.map((tab, index) => (
+					<Popover key={index}>
+						<PopoverTrigger className="hover:bg-card text-muted-foreground hover:text-foreground p-2 py-1 rounded-sm capitalize">
+							<Tran asChild text={tab.label} />
+						</PopoverTrigger>
+						<PopoverContent className="p-1 mx-2 my-4 bg-card grid capitalize space-y-1">
+							{tab.items.map((item, index) => (
+								<PopoverClose key={index} asChild>
+									{item}
+								</PopoverClose>
+							))}
+						</PopoverContent>
+					</Popover>
+				))}
+				<AddNodeDialog />
+			</CatchError>
+		</div>
+	);
+}
+
+function AddNodeDialog() {
+	const {
+		showAddNodeDialog,
+		actions: { addNode, setShowAddNodeDialog },
+	} = useLogicEditor();
+
+	return (
+		<Dialog open={showAddNodeDialog} onOpenChange={setShowAddNodeDialog}>
+			<DialogContent className="p-6 rounded-lg">
+				<Hidden>
+					<DialogTitle />
+					<DialogDescription />
+				</Hidden>
+				{nodeOptions.map((option, index) => (
+					<div className="flex flex-col border-b py-2 gap-2" key={index}>
+						<p className="text-lg">{option.key}</p>
+						<div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+							{option.value.map(([key, item]: any) =>
+								'category' in item && 'children' in item ? (
+									<Popover key={key}>
+										<PopoverTrigger>{item.label}</PopoverTrigger>
+										<PopoverContent className="grid grid-cols-2 gap-2">
+											{Object.entries(item.children).map(([key, value]: [any, any]) => (
+												<DialogClose key={key} className="cursor-pointer hover:text-slate-500 transition-colors" onClick={() => addNode(key)}>
+													{value.label}
+												</DialogClose>
+											))}
+										</PopoverContent>
+									</Popover>
+								) : (
+									<DialogClose key={key as any} className="cursor-pointer hover:text-slate-500 transition-colors" onClick={() => addNode(key as unknown as any)}>
+										{item.label}
+									</DialogClose>
+								),
+							)}
+						</div>
+					</div>
+				))}
+			</DialogContent>
+		</Dialog>
+	);
+}
 
 function ZoomIn() {
 	const { zoomIn } = useReactFlow();
@@ -192,73 +259,4 @@ function ShortcutHandler() {
 	});
 
 	return <></>;
-}
-
-export default function ToolBar() {
-	return (
-		<div className="min-h-nav border-b overflow-x-auto p-1 flex items-center w-full">
-			<CatchError>
-				<ShortcutHandler />
-				<LogicEditorNavBar />
-				{tabs.map((tab, index) => (
-					<Popover key={index}>
-						<PopoverTrigger className="hover:bg-card text-muted-foreground hover:text-foreground p-2 py-1 rounded-sm capitalize">
-							<Tran asChild text={tab.label} />
-						</PopoverTrigger>
-						<PopoverContent className="p-1 mx-2 my-4 bg-card grid capitalize space-y-1">
-							{tab.items.map((item, index) => (
-								<PopoverClose key={index} asChild>
-									{item}
-								</PopoverClose>
-							))}
-						</PopoverContent>
-					</Popover>
-				))}
-				<AddNodeDialog />
-			</CatchError>
-		</div>
-	);
-}
-
-function AddNodeDialog() {
-	const {
-		showAddNodeDialog,
-		actions: { addNode, setShowAddNodeDialog },
-	} = useLogicEditor();
-
-	return (
-		<Dialog open={showAddNodeDialog} onOpenChange={setShowAddNodeDialog}>
-			<DialogContent className="p-6 rounded-lg">
-				<Hidden>
-					<DialogTitle />
-					<DialogDescription />
-				</Hidden>
-				{nodeOptions.map((option, index) => (
-					<div className="flex flex-col border-b py-2 gap-2" key={index}>
-						<p className="text-lg">{option.key}</p>
-						<div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-							{option.value.map(([key, item]: any) =>
-								'category' in item && 'children' in item ? (
-									<Popover key={key}>
-										<PopoverTrigger>{item.label}</PopoverTrigger>
-										<PopoverContent className="grid grid-cols-2 gap-2">
-											{Object.entries(item.children).map(([key, value]: [any, any]) => (
-												<DialogClose key={key} className="cursor-pointer hover:text-slate-500 transition-colors" onClick={() => addNode(key)}>
-													{value.label}
-												</DialogClose>
-											))}
-										</PopoverContent>
-									</Popover>
-								) : (
-									<DialogClose key={key as any} className="cursor-pointer hover:text-slate-500 transition-colors" onClick={() => addNode(key as unknown as any)}>
-										{item.label}
-									</DialogClose>
-								),
-							)}
-						</div>
-					</div>
-				))}
-			</DialogContent>
-		</Dialog>
-	);
 }

--- a/app/[locale]/logic/toolbar.tsx
+++ b/app/[locale]/logic/toolbar.tsx
@@ -47,7 +47,7 @@ export default function ToolBar() {
 				<ShortcutHandler />
 				{tabs.map((tab, index) => (
 					<Popover key={index}>
-						<PopoverTrigger className="hover:bg-card text-muted-foreground hover:text-foreground p-2 py-1 rounded-sm capitalize">
+						<PopoverTrigger className="hover:bg-secondary text-muted-foreground hover:text-foreground p-2 py-1 rounded-sm capitalize">
 							<Tran asChild text={tab.label} />
 						</PopoverTrigger>
 						<PopoverContent className="p-1 mx-2 my-4 bg-card grid capitalize space-y-1">


### PR DESCRIPTION
Ensure that the `filterdItems` logic correctly handles cases where `condition` is undefined, preventing potential runtime errors. Additionally, adjust the import order and formatting in the logic editor context for better readability.