### PR TITLE
refactor(hooks): integrate pagination size from cookies in useInfinit…

### DIFF
--- a/components/common/grid-pagination-list.tsx
+++ b/components/common/grid-pagination-list.tsx
@@ -16,87 +16,100 @@ import { QuerySchema } from '@/query/search-query';
 import { QueryKey, useQuery } from '@tanstack/react-query';
 
 type Props<T, P extends QuerySchema> = {
-  className?: string;
-  queryKey: QueryKey;
-  paramSchema: P;
-  params?: Omit<z.infer<P>, 'page' | 'size'>;
-  loader?: ReactNode;
-  noResult?: ReactNode;
-  skeleton?: {
-    amount: number;
-    item: ReactNode | ((index: number) => ReactNode);
-  };
-  asChild?: boolean;
-  initialData?: T[];
-  initialParams?: z.infer<P>;
-  queryFn: (axios: AxiosInstance, params: z.infer<P>) => Promise<T[]>;
-  children: (data: T, index: number) => ReactNode;
+	className?: string;
+	queryKey: QueryKey;
+	paramSchema: P;
+	params?: Omit<z.infer<P>, 'page' | 'size'>;
+	loader?: ReactNode;
+	noResult?: ReactNode;
+	skeleton?: {
+		amount: number;
+		item: ReactNode | ((index: number) => ReactNode);
+	};
+	asChild?: boolean;
+	initialData?: T[];
+	initialParams?: z.infer<P>;
+	queryFn: (axios: AxiosInstance, params: z.infer<P>) => Promise<T[]>;
+	children: (data: T, index: number) => ReactNode;
 };
 
-export default function GridPaginationList<T, P extends QuerySchema>({ className, queryKey, paramSchema, loader, noResult, skeleton, asChild, initialData, initialParams, params, queryFn, children }: Props<T, P>) {
-  const p = useSearchQuery(paramSchema, params);
+export default function GridPaginationList<T, P extends QuerySchema>({
+	className,
+	queryKey,
+	paramSchema,
+	loader,
+	noResult,
+	skeleton,
+	asChild,
+	initialData,
+	initialParams,
+	params,
+	queryFn,
+	children,
+}: Props<T, P>) {
+	const p = useSearchQuery(paramSchema, params);
 
-  const axios = useClientApi();
-  const { data, error, isLoading } = useQuery({
-    queryFn: () => queryFn(axios, p),
-    queryKey: [p, ...queryKey],
-    initialData: JSON.stringify(p) === JSON.stringify(initialParams) ? initialData : undefined,
-  });
+	const axios = useClientApi();
+	const { data, error, isLoading } = useQuery({
+		queryFn: () => queryFn(axios, p),
+		queryKey: [p, ...queryKey],
+		initialData: JSON.stringify(p) === JSON.stringify(initialParams) ? initialData : undefined,
+	});
 
-  const skeletonElements = useMemo(() => {
-    if (skeleton)
-      return Array(skeleton.amount)
-        .fill(1)
-        .map((_, index) => <React.Fragment key={index}>{typeof skeleton.item === 'function' ? skeleton.item(index) : skeleton.item}</React.Fragment>);
-  }, [skeleton]);
+	const skeletonElements = useMemo(() => {
+		if (skeleton)
+			return Array(skeleton.amount)
+				.fill(1)
+				.map((_, index) => <React.Fragment key={index}>{typeof skeleton.item === 'function' ? skeleton.item(index) : skeleton.item}</React.Fragment>);
+	}, [skeleton]);
 
-  noResult = useMemo(() => noResult ?? <NoResult className="flex w-full items-center justify-center" />, [noResult]);
-  loader = useMemo(() => (!loader && !skeleton ? <LoadingSpinner key="loading" className="col-span-full flex h-full w-full items-center justify-center" /> : undefined), [loader, skeleton]);
+	noResult = useMemo(() => noResult ?? <NoResult className="flex w-full items-center justify-center" />, [noResult]);
+	loader = useMemo(() => (!loader && !skeleton ? <LoadingSpinner key="loading" className="col-span-full flex h-full w-full items-center justify-center" /> : undefined), [loader, skeleton]);
 
-  if (asChild) {
-    return (
-      <Render isLoading={isLoading} loader={loader} skeletonElements={skeletonElements} error={error} data={data} noResult={noResult}>
-        {children}
-      </Render>
-    );
-  }
+	if (asChild) {
+		return (
+			<Render isLoading={isLoading} loader={loader} skeletonElements={skeletonElements} error={error} data={data} noResult={noResult}>
+				{children}
+			</Render>
+		);
+	}
 
-  return (
-    <div className="scroll-container h-full">
-      <section className={cn('grid w-full grid-cols-[repeat(auto-fill,minmax(min(var(--preview-size),100%),1fr))] justify-center gap-2', className)}>
-        <Render isLoading={isLoading} loader={loader} skeletonElements={skeletonElements} error={error} data={data} noResult={noResult}>
-          {children}
-        </Render>
-      </section>
-    </div>
-  );
+	return (
+		<div className="scroll-container h-full">
+			<section className={cn('grid w-full grid-cols-[repeat(auto-fill,minmax(min(var(--preview-size),100%),1fr))] justify-center gap-2', className)}>
+				<Render isLoading={isLoading} loader={loader} skeletonElements={skeletonElements} error={error} data={data} noResult={noResult}>
+					{children}
+				</Render>
+			</section>
+		</div>
+	);
 }
 
 type RenderProps<T> = {
-  isLoading: boolean;
-  loader: ReactNode;
-  skeletonElements?: React.JSX.Element[];
-  error: any;
-  data?: T[];
-  noResult: ReactNode;
-  children: (data: T, index: number) => ReactNode;
+	isLoading: boolean;
+	loader: ReactNode;
+	skeletonElements?: React.JSX.Element[];
+	error: any;
+	data?: T[];
+	noResult: ReactNode;
+	children: (data: T, index: number) => ReactNode;
 };
 function Render<T>({ isLoading, loader, skeletonElements, error, data, noResult, children }: RenderProps<T>) {
-  if (isLoading) {
-    return loader ? loader : skeletonElements;
-  }
+	if (isLoading) {
+		return loader ? loader : skeletonElements;
+	}
 
-  if (error) {
-    return (
-      <div className="col-span-full flex h-full w-full justify-center">
-        <RouterSpinner message={error?.message} />
-      </div>
-    );
-  }
+	if (error) {
+		return (
+			<div className="col-span-full flex h-full w-full justify-center">
+				<RouterSpinner message={error?.message} />
+			</div>
+		);
+	}
 
-  if (!data) {
-    return noResult;
-  }
+	if (!data) {
+		return noResult;
+	}
 
-  return data.map((item, index) => children(item, index));
+	return data.map((item, index) => children(item, index));
 }

--- a/hooks/use-infinite-page-query.ts
+++ b/hooks/use-infinite-page-query.ts
@@ -1,52 +1,63 @@
 import { AxiosInstance } from 'axios';
+import { useCookies } from 'react-cookie';
 
+import { PAGINATION_SIZE_PERSISTENT_KEY } from '@/context/session-context.type';
 import useClientApi from '@/hooks/use-client';
 import { PaginationQuery } from '@/query/search-query';
 
 import { InfiniteData, QueryKey, useInfiniteQuery } from '@tanstack/react-query';
 
-export default function useInfinitePageQuery<T, P extends PaginationQuery>(queryFn: (axios: AxiosInstance, params: P) => Promise<T[]>, params: P, queryKey: QueryKey, initialData?: T[], enabled?: boolean) {
-  const axios = useClientApi();
+export default function useInfinitePageQuery<T, P extends PaginationQuery>(
+	queryFn: (axios: AxiosInstance, params: P) => Promise<T[]>,
+	params: P,
+	queryKey: QueryKey,
+	initialData?: T[],
+	enabled?: boolean,
+) {
+	const axios = useClientApi();
+	const [{ paginationSize }] = useCookies([PAGINATION_SIZE_PERSISTENT_KEY]);
 
-  const getNextPageParam = (lastPage: T[], allPages: T[][], lastPageParams: P) => {
-    if (lastPage.length === 0 || lastPage.length < params.size) {
-      return undefined;
-    }
+	const size = paginationSize ?? 0;
 
-    return { ...lastPageParams, page: allPages.length };
-  };
+	const getNextPageParam = (lastPage: T[], allPages: T[][], lastPageParams: P) => {
+		if (lastPage.length === 0 || lastPage.length < size) {
+			return undefined;
+		}
 
-  const getPreviousPageParam = (lastPage: T[], allPages: T[][], lastPageParams: P) => {
-    if (lastPageParams.page <= 0 || lastPage.length === 0 || lastPage.length < params.size) {
-      return undefined;
-    }
+		return { ...lastPageParams, page: allPages.length, size };
+	};
 
-    return { ...lastPageParams, page: allPages.length - 1 };
-  };
+	const getPreviousPageParam = (lastPage: T[], allPages: T[][], lastPageParams: P) => {
+		if (lastPageParams.page <= 0 || lastPage.length === 0 || lastPage.length < size) {
+			return undefined;
+		}
 
-  // Remove page and size from key
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { page, ...rest } = params;
+		return { ...lastPageParams, page: allPages.length - 1, size };
+	};
 
-  let filteredQueryKey: any[];
+	// Remove page and size from key
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const { page, ...rest } = params;
 
-  if (Object.keys(rest).length > 0) {
-    filteredQueryKey = [...queryKey, rest];
-  } else {
-    filteredQueryKey = [...queryKey];
-  }
+	let filteredQueryKey: any[];
 
-  const data: InfiniteData<T[], P> | undefined = initialData ? { pages: [initialData], pageParams: [params] } : undefined;
+	if (Object.keys(rest).length > 0) {
+		filteredQueryKey = [...queryKey, rest];
+	} else {
+		filteredQueryKey = [...queryKey];
+	}
 
-  return useInfiniteQuery<T[], Error, InfiniteData<T[], P>, QueryKey, P>({
-    queryKey: filteredQueryKey,
-    initialPageParam: params,
-    // TODO: Fix this
-    initialData: data,
-    enabled,
-    // @ts-expect-error idk
-    queryFn: (context) => queryFn(axios, context.pageParam),
-    getNextPageParam,
-    getPreviousPageParam,
-  });
+	const data: InfiniteData<T[], P> | undefined = initialData ? { pages: [initialData], pageParams: [params] } : undefined;
+
+	return useInfiniteQuery<T[], Error, InfiniteData<T[], P>, QueryKey, P>({
+		queryKey: filteredQueryKey,
+		initialPageParam: params,
+		// TODO: Fix this
+		initialData: data,
+		enabled,
+		// @ts-expect-error idk
+		queryFn: (context) => queryFn(axios, context.pageParam),
+		getNextPageParam,
+		getPreviousPageParam,
+	});
 }


### PR DESCRIPTION
…ePageQuery

This commit modifies the `useInfinitePageQuery` hook to use the pagination size stored in cookies, ensuring consistency across the application. The `getNextPageParam` and `getPreviousPageParam` functions now utilize this value for pagination calculations. Additionally, the code has been formatted for better readability.