### PR TITLE
style(button): update command button hover background color

### DIFF
--- a/components/button/copy-button.tsx
+++ b/components/button/copy-button.tsx
@@ -12,7 +12,7 @@ import { cn } from '@/lib/utils';
 
 import { useMutation } from '@tanstack/react-query';
 
-const copyButtonVariants = cva('flex p-2 bg-transparent group/copy-button rounded-md', {
+const copyButtonVariants = cva('flex p-2 bg-transparent group/copy-button rounded-md items-center justify-center', {
 	variants: {
 		variant: {
 			default: 'bg-secondary border border-border hover:bg-brand hover:border-transparent',

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -21,8 +21,8 @@ const buttonVariants = cva(
 				ghost: 'text-foreground border border-transparent',
 				link: 'text-primary underline-offset-4 hover:underline',
 				icon: 'p-0',
-				command: 'hover:bg-accent justify-start gap-1 rounded-sm p-0 w-full',
-				'command-destructive': 'justify-start gap-1 hover:bg-accent rounded-sm p-0 text-destructive-foreground bg-destructive shadow-sm hover:bg-opacity-90 w-full',
+				command: 'hover:bg-destructive/80 justify-start gap-1 rounded-sm p-0 w-full',
+				'command-destructive': 'justify-start gap-1 hover:bg-destructive/80 rounded-sm p-0 text-destructive-foreground bg-destructive shadow-sm hover:bg-opacity-90 w-full',
 			},
 			size: {
 				default: 'h-9 px-4 py-2',


### PR DESCRIPTION
The hover background color for command buttons was updated to use a more consistent and visually appealing `destructive/80` shade. This change ensures better alignment with the design system and improves the user experience.