### PR TITLE
style(button): adjust copy button height for better consistency

### DIFF
--- a/components/button/copy-button.tsx
+++ b/components/button/copy-button.tsx
@@ -12,7 +12,7 @@ import { cn } from '@/lib/utils';
 
 import { useMutation } from '@tanstack/react-query';
 
-const copyButtonVariants = cva('flex p-2 bg-transparent group/copy-button rounded-md items-center justify-center', {
+const copyButtonVariants = cva('flex h-9 p-2 bg-transparent group/copy-button rounded-md items-center justify-center', {
 	variants: {
 		variant: {
 			default: 'bg-secondary border border-border hover:bg-brand hover:border-transparent',


### PR DESCRIPTION
The height of the copy button was adjusted to `h-9` to ensure better visual consistency with other components in the UI. This change aligns with the design system guidelines.