### PR TITLE
style(layout): adjust NavBarDoc styling for better alignment

### DIFF
--- a/app/[locale]/docs/[...path]/layout.tsx
+++ b/app/[locale]/docs/[...path]/layout.tsx
@@ -210,7 +210,7 @@ function NavBarDoc({
 	}
 
 	return (
-		<Accordion className="space-y-1 w-full h-10" type="single" collapsible defaultValue={selectedSegments.join('/')}>
+		<Accordion className="space-y-1 w-full" type="single" collapsible defaultValue={selectedSegments.join('/')}>
 			<AccordionItem
 				value={
 					selectedSegments

--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -7,29 +7,46 @@ import { ChevronDownIcon } from '@radix-ui/react-icons';
 
 const Accordion = AccordionPrimitive.Root;
 
-const AccordionItem = React.forwardRef<React.ElementRef<typeof AccordionPrimitive.Item>, React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>>(({ className, ...props }, ref) => (
-  <AccordionPrimitive.Item ref={ref} className={cn(className)} {...props} />
-));
+const AccordionItem = React.forwardRef<
+	React.ElementRef<typeof AccordionPrimitive.Item>,
+	React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
+>(({ className, ...props }, ref) => <AccordionPrimitive.Item ref={ref} className={cn(className)} {...props} />);
 AccordionItem.displayName = 'AccordionItem';
 
 type TriggerProps = {
-  showChevron?: boolean;
+	showChevron?: boolean;
 };
 
-const AccordionTrigger = React.forwardRef<React.ElementRef<typeof AccordionPrimitive.Trigger>, React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger> & TriggerProps>(({ className, children, showChevron = true, ...props }, ref) => (
-  <AccordionPrimitive.Header className="flex py-0">
-    <AccordionPrimitive.Trigger ref={ref} className={cn('flex flex-1 items-center justify-between py-4 text-sm font-medium transition-all group', className)} {...props}>
-      {children}
-      {showChevron && <ChevronDownIcon className="size-5 ml-auto mr-2 shrink-0 transition-transform duration-200 group-aria-expanded:rotate-0 -rotate-90 dark:text-foreground dark:hover:text-foreground" />}
-    </AccordionPrimitive.Trigger>
-  </AccordionPrimitive.Header>
+const AccordionTrigger = React.forwardRef<
+	React.ElementRef<typeof AccordionPrimitive.Trigger>,
+	React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger> & TriggerProps
+>(({ className, children, showChevron = true, ...props }, ref) => (
+	<AccordionPrimitive.Header className="flex py-0">
+		<AccordionPrimitive.Trigger
+			ref={ref}
+			className={cn('flex h-10 flex-1 items-center justify-between py-4 text-sm font-medium transition-all group', className)}
+			{...props}
+		>
+			{children}
+			{showChevron && (
+				<ChevronDownIcon className="size-5 ml-auto mr-2 shrink-0 transition-transform duration-200 group-aria-expanded:rotate-0 -rotate-90 dark:text-foreground dark:hover:text-foreground" />
+			)}
+		</AccordionPrimitive.Trigger>
+	</AccordionPrimitive.Header>
 ));
 AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName;
 
-const AccordionContent = React.forwardRef<React.ElementRef<typeof AccordionPrimitive.Content>, React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>>(({ className, children, ...props }, ref) => (
-  <AccordionPrimitive.Content ref={ref} className="overflow-hidden text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down" {...props}>
-    <div className={cn('pt-1', className)}>{children}</div>
-  </AccordionPrimitive.Content>
+const AccordionContent = React.forwardRef<
+	React.ElementRef<typeof AccordionPrimitive.Content>,
+	React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+	<AccordionPrimitive.Content
+		ref={ref}
+		className="overflow-hidden text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+		{...props}
+	>
+		<div className={cn('pt-1', className)}>{children}</div>
+	</AccordionPrimitive.Content>
 ));
 AccordionContent.displayName = AccordionPrimitive.Content.displayName;
 


### PR DESCRIPTION
The `NavBarDoc` component's styling was updated to use `min-h-10` and `flex items-center` to ensure consistent height and vertical alignment of its content. This improves the visual consistency and layout of the navigation bar.