### PR TITLE
fix(servers): correct server status check for RemoveServerButton

### DIFF
--- a/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
@@ -176,7 +176,7 @@ export default async function Page({ params }: Props) {
 					</div>
 					<ProtectedElement session={session} filter={canAccess}>
 						<div className={cn('flex flex-row items-center justify-end gap-2 bg-card rounded-md p-2 shadow-lg mt-auto')}>
-							{status !== 'HOST' && <RemoveServerButton id={id} />}
+							{status !== 'DELETED' && <RemoveServerButton id={id} />}
 							{status !== 'DOWN' && <ShutdownServerButton id={id} />}
 							{status === 'HOST' ? <StopServerButton id={id} /> : status === 'UP' ? <HostServerButton id={id} /> : <InitServerButton id={id} />}
 						</div>

--- a/types/response/ServerDto.ts
+++ b/types/response/ServerDto.ts
@@ -1,23 +1,23 @@
 import { ServerMode } from '@/types/request/UpdateServerRequest';
 
-export type ServerStatus = 'DOWN' | 'UP' | 'HOST';
+export type ServerStatus = 'DOWN' | 'UP' | 'HOST' | 'DELETED';
 
 export type ServerDto = {
-  id: string;
-  name: string;
-  userId: string;
-  description: string;
-  port: number;
-  isOfficial: boolean;
-  mode: ServerMode;
-  status: ServerStatus;
-  ramUsage: number;
-  cpuUsage: number;
-  totalRam: number;
-  players: number;
-  mapName: string;
-  address: string;
-  isAutoTurnOff: boolean;
-  isHub: boolean;
-  hostCommand?: string;
+	id: string;
+	name: string;
+	userId: string;
+	description: string;
+	port: number;
+	isOfficial: boolean;
+	mode: ServerMode;
+	status: ServerStatus;
+	ramUsage: number;
+	cpuUsage: number;
+	totalRam: number;
+	players: number;
+	mapName: string;
+	address: string;
+	isAutoTurnOff: boolean;
+	isHub: boolean;
+	hostCommand?: string;
 };


### PR DESCRIPTION
The condition for displaying the RemoveServerButton was updated from checking if the status is not 'HOST' to checking if the status is not 'DELETED'. This ensures the button is displayed correctly based on the server's lifecycle state. Additionally, the ServerStatus type was updated to include 'DELETED' as a valid status.