### PR TITLE
feat(server): add image field to server update form and types

### DIFF
--- a/app/[locale]/(main)/servers/[id]/setting/server-update-form.tsx
+++ b/app/[locale]/(main)/servers/[id]/setting/server-update-form.tsx
@@ -21,7 +21,7 @@ import { PutServerRequest, PutServerSchema, ServerModes } from '@/types/request/
 import Server from '@/types/response/Server';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 
 type Props = {
 	server: Server;
@@ -51,12 +51,20 @@ export default function ServerUpdateForm({ server }: Props) {
 		},
 	});
 
+	const { data: images } = useQuery({
+		queryKey: ['server-images'],
+		queryFn: () => axios.get('/servers/images').then((res) => res.data as string[]),
+	});
+
 	const isChanged = form.formState.isDirty;
 
 	return (
 		<div className="relative flex h-full flex-col justify-between gap-2">
 			<Form {...form}>
-				<form className="flex flex-1 flex-col justify-between bg-card rounded-md p-6 h-full" onSubmit={form.handleSubmit((value) => mutate(value))}>
+				<form
+					className="flex flex-1 flex-col justify-between bg-card rounded-md p-6 h-full"
+					onSubmit={form.handleSubmit((value) => mutate(value))}
+				>
 					<FormField
 						control={form.control}
 						name="name"
@@ -68,7 +76,9 @@ export default function ServerUpdateForm({ server }: Props) {
 								<FormControl>
 									<Input placeholder="Test" {...field} />
 								</FormControl>
-								<FormDescription>{field.value ? <ColorText text={field.value} /> : <Tran text="server.name-description" />}</FormDescription>
+								<FormDescription>
+									{field.value ? <ColorText text={field.value} /> : <Tran text="server.name-description" />}
+								</FormDescription>
 								<FormMessage />
 							</FormItem>
 						)}
@@ -82,7 +92,9 @@ export default function ServerUpdateForm({ server }: Props) {
 								<FormControl>
 									<Input placeholder="Some cool stuff" {...field} />
 								</FormControl>
-								<FormDescription>{field.value ? <ColorText text={field.value} /> : <Tran text="server.description-description" />}</FormDescription>
+								<FormDescription>
+									{field.value ? <ColorText text={field.value} /> : <Tran text="server.description-description" />}
+								</FormDescription>
 								<FormMessage />
 							</FormItem>
 						)}
@@ -109,6 +121,34 @@ export default function ServerUpdateForm({ server }: Props) {
 								</FormControl>
 								<FormDescription>
 									<Tran text="server.game-mode-description" />
+								</FormDescription>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+					<FormField
+						control={form.control}
+						name="image"
+						render={({ field }) => (
+							<FormItem className="grid">
+								<FormLabel>
+									<Tran text="server.image" />
+								</FormLabel>
+								<FormControl>
+									<ComboBox
+										searchBar={false}
+										value={{ label: field.value, value: field.value }}
+										values={
+											images?.map((value) => ({
+												label: value,
+												value,
+											})) ?? []
+										}
+										onChange={(value) => field.onChange(value)}
+									/>
+								</FormControl>
+								<FormDescription>
+									<Tran text="server.image-description" />
 								</FormDescription>
 								<FormMessage />
 							</FormItem>
@@ -155,10 +195,22 @@ export default function ServerUpdateForm({ server }: Props) {
 							'opacity-100 translate-y-0': isChanged,
 						})}
 					>
-						<Button className="flex justify-end" variant="secondary" title="reset" onClick={() => form.reset()} disabled={!isChanged || isPending}>
+						<Button
+							className="flex justify-end"
+							variant="secondary"
+							title="reset"
+							onClick={() => form.reset()}
+							disabled={!isChanged || isPending}
+						>
 							<Tran text="reset" />
 						</Button>
-						<Button className="flex justify-end" variant="primary" type="submit" title="update" disabled={!isChanged || isPending}>
+						<Button
+							className="flex justify-end"
+							variant="primary"
+							type="submit"
+							title="update"
+							disabled={!isChanged || isPending}
+						>
 							<Tran text="update" />
 						</Button>
 					</div>

--- a/types/request/UpdateServerRequest.ts
+++ b/types/request/UpdateServerRequest.ts
@@ -5,20 +5,21 @@ export const ServerModes = ['SURVIVAL', 'ATTACK', 'PVP', 'SANDBOX'] as const;
 export type ServerMode = (typeof ServerModes)[number];
 
 export const PutServerSchema = z.object({
-  name: z.string().min(1).max(50),
-  description: z.string().min(1).max(200),
-  mode: z.enum(ServerModes).default('SURVIVAL'),
-  hostCommand: z.string().max(1000).optional().nullable(),
-  webhook: z.string().max(1000).optional().nullable(),
+	name: z.string().min(1).max(50),
+	description: z.string().min(1).max(200),
+	mode: z.enum(ServerModes).default('SURVIVAL'),
+	hostCommand: z.string().max(1000).optional().nullable(),
+	webhook: z.string().max(1000).optional().nullable(),
+	image: z.string().max(1000),
 });
 
 export type PutServerRequest = z.infer<typeof PutServerSchema>;
 
 export const PutServerPortSchema = z.object({
-  port: z.coerce.number().min(1).int(),
-  isOfficial: z.boolean(),
-  isHub: z.boolean(),
-  isAutoTurnOff: z.boolean(),
+	port: z.coerce.number().min(1).int(),
+	isOfficial: z.boolean(),
+	isHub: z.boolean(),
+	isAutoTurnOff: z.boolean(),
 });
 
 export type PutServerPortRequest = z.infer<typeof PutServerPortSchema>;

--- a/types/response/Server.ts
+++ b/types/response/Server.ts
@@ -1,18 +1,19 @@
 import { ServerMode } from '@/types/request/UpdateServerRequest';
 
 export default interface Server {
-  id: string;
-  userId: string;
-  managerId: string;
-  port: number;
-  name: string;
-  description: string;
-  mode: ServerMode;
-  gamemode: string | null;
-  isOfficial: boolean;
-  hostCommand: string | null;
-  address: string;
-  webhook: string | null;
-  isAutoTurnOff: boolean;
-  isHub: boolean;
+	id: string;
+	userId: string;
+	managerId: string;
+	port: number;
+	name: string;
+	description: string;
+	mode: ServerMode;
+	gamemode: string | null;
+	isOfficial: boolean;
+	hostCommand: string | null;
+	address: string;
+	image: string;
+	webhook: string | null;
+	isAutoTurnOff: boolean;
+	isHub: boolean;
 }


### PR DESCRIPTION
Add an `image` field to the `Server` interface and `PutServerSchema` to support server image selection. Update the server update form to include a combo box for selecting an image from a list of available server images.