### PR TITLE
refactor(image-generator): change data type from string to Blob for m…

### DIFF
--- a/app/[locale]/(main)/image-generator/map/page.tsx
+++ b/app/[locale]/(main)/image-generator/map/page.tsx
@@ -35,7 +35,9 @@ export default function Page() {
 				const formData = new FormData();
 				formData.append('image', image);
 
-				return axios.post('/image-generator/map', formData, { data: formData }).then((result) => result.data as string);
+				return axios
+					.post('/image-generator/map', formData, { data: formData, responseType: 'blob' })
+					.then((result) => result.data as Blob);
 			}
 			return Promise.reject(new Error('No image selected'));
 		},
@@ -76,7 +78,7 @@ export default function Page() {
 	);
 }
 
-function Preview({ data }: { data: string }) {
+function Preview({ data }: { data: Blob }) {
 	const axios = useClientApi();
 
 	const {
@@ -86,7 +88,7 @@ function Preview({ data }: { data: string }) {
 		error,
 	} = useQuery({
 		queryKey: ['map-preview', data],
-		queryFn: () => (data ? getMapPreview(axios, { file: data }) : null),
+		queryFn: () => (data ? getMapPreview(axios, { file: new File([data], 'map.msav') }) : null),
 	});
 
 	if (isLoading) {
@@ -114,10 +116,9 @@ function Preview({ data }: { data: string }) {
 	);
 }
 
-function DownloadButton({ data }: { data: string }) {
+function DownloadButton({ data }: { data: Blob }) {
 	function download() {
-		const blob = new Blob([data], { type: 'text/plain;charset=utf-8;' });
-		saveAs(blob, 'image.msav');
+		saveAs(data, 'image.msav');
 	}
 
 	return (

--- a/types/request/MapPreviewRequest.ts
+++ b/types/request/MapPreviewRequest.ts
@@ -1,5 +1,5 @@
 type MapPreviewRequest = {
-	file: File | string;
+	file: File;
 };
 
 export default MapPreviewRequest;


### PR DESCRIPTION
…ap preview

This commit updates the data type used for map preview and download functionality from `string` to `Blob`. This change ensures consistency with the expected file handling and improves the accuracy of file operations, such as saving the map preview as a file. The `MapPreviewRequest` type is also simplified by removing the `string` option for the `file` property, as it is no longer needed.