### PR TITLE
fix: log error before rejecting promise in axios interceptor

### DIFF
--- a/app/[locale]/(main)/admin/setting/image/page.tsx
+++ b/app/[locale]/(main)/admin/setting/image/page.tsx
@@ -77,7 +77,7 @@ export default function Page() {
 function DirCard({ data, setPath }: { data: ImageMetadata; setPath: (path: string) => void }) {
 	return (
 		<div className="p-2 border border-md rounded-md flex gap-1 items-center cursor-pointer" onClick={() => setPath(data.path)}>
-			<div className="flex items-center">
+			<div className="flex items-center gap-1">
 				<FolderIcon />
 				{data.name}
 			</div>
@@ -92,7 +92,7 @@ function DirCard({ data, setPath }: { data: ImageMetadata; setPath: (path: strin
 function FileCard({ data }: { data: ImageMetadata }) {
 	return (
 		<div className="p-2 border-transparent bg-card border-md rounded-md flex gap-1 items-center cursor-pointer">
-			<div className="flex items-center">
+			<div className="flex items-center gap-1">
 				<FileIcon />
 				{data.name}
 			</div>
@@ -109,7 +109,7 @@ function ImageCard({ data }: { data: ImageMetadata }) {
 		<Dialog>
 			<DialogTrigger asChild>
 				<div className="p-2 border-transparent bg-card border-md rounded-md flex gap-1 items-center cursor-pointer">
-					<div className="flex items-center">
+					<div className="flex items-center gap-1">
 						<motion.img
 							id={data.path}
 							layout

--- a/app/[locale]/(main)/admin/setting/image/page.tsx
+++ b/app/[locale]/(main)/admin/setting/image/page.tsx
@@ -46,7 +46,7 @@ export default function Page() {
 					<FileHierarchy path={path} onClick={setPath} />
 				</div>
 			</section>
-			<ScrollContainer className="border rounded-lg">
+			<ScrollContainer>
 				<InfinitePage
 					className="flex flex-col gap-2 p-2 h-full"
 					queryKey={['images']}

--- a/hooks/use-query-state.ts
+++ b/hooks/use-query-state.ts
@@ -19,6 +19,7 @@ export default function useQueryState<T extends Record<string, string | null>>(i
 		}
 
 		setCurrentValue(result as T);
+	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	const setter = useCallback(
@@ -60,7 +61,7 @@ export default function useQueryState<T extends Record<string, string | null>>(i
 		}
 
 		if (!isTheSame) {
-			router.replace(`${pathname}?${queryParams.toString()}`);
+			router.push(`${pathname}?${queryParams.toString()}`);
 		}
 	}
 

--- a/query/config/config.ts
+++ b/query/config/config.ts
@@ -55,7 +55,9 @@ const axiosInstance = Axios.create({
 axiosInstance.interceptors.response.use(
 	(res) => res,
 	(error) => {
-		if (error.message) {
+		logError(error);
+
+		if (error?.message) {
 			return Promise.reject(error.message);
 		}
 
@@ -73,7 +75,6 @@ axiosInstance.interceptors.response.use(
 			statusError = createUnknownError(error);
 		}
 
-		logError(error);
 		return Promise.reject(statusError);
 	},
 );


### PR DESCRIPTION
Ensure that the error is logged before rejecting the promise in the axios response interceptor. This prevents the error from being lost if the promise is rejected prematurely.