### PR TITLE
fix(player-card): correct query key from 'players' to 'player'

### DIFF
--- a/app/[locale]/(main)/servers/[id]/(dashboard)/player-card.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/player-card.tsx
@@ -22,7 +22,7 @@ type PlayersCardProps = {
 export function PlayersCard({ id }: PlayersCardProps) {
 	const axios = useClientApi();
 	const { data, isError, error } = useSuspenseQuery({
-		queryKey: ['server', id, 'players'],
+		queryKey: ['server', id, 'player'],
 		queryFn: () => getServerPlayers(axios, id),
 	});
 


### PR DESCRIPTION
The query key was updated to match the expected API endpoint, ensuring the correct data is fetched for the player card component.