### PR TITLE
refactor(server-card): remove unused CopyButton and address prop

### DIFF
--- a/app/[locale]/logic/node.tsx
+++ b/app/[locale]/logic/node.tsx
@@ -13,7 +13,10 @@
 // Autocomplete
 import { InstructionNode } from '@/app/[locale]/logic/instruction.node';
 
+
+
 import { groupBy } from '@/lib/utils';
+
 
 export type ItemsType = Readonly<NodeItem[]>;
 export type OutputsType = Readonly<Output[]>;
@@ -735,8 +738,9 @@ export const instructionNodes: Record<string, NodeData> = Object.entries(instruc
 		if (value instanceof NodeData) {
 			acc[key] = value;
 		} else {
-			Object.entries(value.children).forEach(([key, value]) => {
-				acc[key] = value;
+			Object.entries(value.children).forEach(([key, child]) => {
+				child.label = value.label + ' ' + child.label;
+				acc[key] = child;
 			});
 		}
 

--- a/app/[locale]/logic/plus.panel.tsx
+++ b/app/[locale]/logic/plus.panel.tsx
@@ -30,7 +30,7 @@ function InstructionList() {
 		<div className="space-y-4 flex flex-col h-full overflow-hiden">
 			<div>
 				<h2 className="text-base">
-					<Tran text="logic.instruction-list" />
+					<Tran text="logic.instruction-list" defaultValue="Instruction list" />
 				</h2>
 				<Input placeholder="Search" value={filter} onChange={(event) => setFilter(event.currentTarget.value)} />
 			</div>

--- a/components/server/server-card.tsx
+++ b/components/server/server-card.tsx
@@ -1,6 +1,5 @@
 import React, { Fragment, Suspense } from 'react';
 
-import CopyButton from '@/components/button/copy.button';
 import ColorText from '@/components/common/color-text';
 import InternalLink from '@/components/common/internal-link';
 import Tran from '@/components/common/tran';
@@ -14,7 +13,7 @@ type MyServerInstancesCardProps = {
 };
 
 export default function ServerCard({
-	server: { id, name, players, port, status, mapName, mode, address, isOfficial },
+	server: { id, name, players, port, status, mapName, mode, isOfficial },
 }: MyServerInstancesCardProps) {
 	return (
 		<InternalLink
@@ -22,7 +21,6 @@ export default function ServerCard({
 			href={`/servers/${id}`}
 		>
 			<Suspense>
-				<CopyButton data={address} variant="ghost" position="absolute-right" />
 				<div className="flex items-start gap-2 flex-nowrap w-full overflow-hidden text-ellipsis justify-between">
 					<ColorText className="text-2xl font-bold" text={name} />
 					{isOfficial && (


### PR DESCRIPTION
The CopyButton component and the address prop were removed as they were no longer used in the ServerCard component. This simplifies the component and reduces unnecessary code.