### PR TITLE
style(server-card): add text-nowrap to map name container

### DIFF
--- a/components/server/server-card.tsx
+++ b/components/server/server-card.tsx
@@ -54,7 +54,7 @@ export default function ServerCard({
 							</Fragment>
 						)}
 					</div>
-					<div className="flex flex-col gap-0.5">
+					<div className="flex flex-col gap-0.5 text-nowrap">
 						{mapName && (
 							<Fragment>
 								<Tran asChild text="server.map" />


### PR DESCRIPTION
This change ensures that the map name text does not wrap, improving readability and layout consistency in the server card component.