### PR TITLE
fix(server-status): replace unknown status with Badge component

### DIFF
--- a/components/server/server-status.tsx
+++ b/components/server/server-status.tsx
@@ -51,7 +51,7 @@ export default function ServerStatus({ status }: Props) {
 			);
 		}
 
-		return <div>Unknown</div>;
+		return <Badge variant="destructive">{status}</Badge>
 	}
 
 	return <div>{render()}</div>;


### PR DESCRIPTION
The previous implementation displayed "Unknown" for unrecognized server statuses, which was not user-friendly. This change replaces it with a `Badge` component that visually indicates the status, improving the user experience by making it clear when the server status is unexpected.