### PR TITLE
refactor(ScrollContainer): simplify component by removing unused stat…

### DIFF
--- a/app/[locale]/logic/file.panel.tsx
+++ b/app/[locale]/logic/file.panel.tsx
@@ -6,7 +6,7 @@ import { useLogicEditor } from '@/app/[locale]/logic/logic-editor.context';
 import RemoveButton from '@/components/button/remove.button';
 import { FileIcon } from '@/components/common/icons';
 import Tran from '@/components/common/tran';
-import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from '@/components/ui/context-menu';
+import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from '@/components/ui/context-menu';
 import { Input } from '@/components/ui/input';
 
 import useLogicFile from '@/hooks/use-logic-file';
@@ -50,7 +50,9 @@ export default function FilePanel() {
 								</button>
 							</ContextMenuTrigger>
 							<ContextMenuContent>
-								<RemoveButton variant="command" isLoading={false} onClick={() => handleDeleteFile(name)} description={''} />
+								<ContextMenuItem asChild>
+									<RemoveButton variant="command" isLoading={false} onClick={() => handleDeleteFile(name)} description={''} />
+								</ContextMenuItem>
 							</ContextMenuContent>
 						</ContextMenu>
 					))}

--- a/app/[locale]/logic/logic-editor.context.tsx
+++ b/app/[locale]/logic/logic-editor.context.tsx
@@ -418,35 +418,6 @@ export function LogicEditorProvider({ children }: { children: React.ReactNode })
 		[save, load, redo, undo, addNode, setShowMiniMap, setShowLiveCode],
 	);
 
-	useEffect(() => {
-		function generateNewFile() {
-			const newName = generateRandomName();
-
-			if (!newName) {
-				toast.error(<Tran text="logic.could-not-generate-random-name" />);
-			} else {
-				addNewFile(newName);
-				setName(newName);
-			}
-		}
-
-		if (name === saved.currentFile) {
-			setLoading(false)
-			return;
-		}
-
-		if (saved.currentFile) {
-			const result = load(saved.currentFile);
-
-			if (!result) {
-				toast.error(<Tran text="logic.load-file-fail" defaultValue="Fail to load file" />, {
-					description: saved.currentFile,
-				});
-				generateNewFile();
-			}
-		}
-	}, [name, saved.currentFile, generateRandomName, load, addNewFile]);
-
 	const [{ handlerId }, drop] = useDrop<any, void, { handlerId: Identifier | null }>({
 		accept: 'instruction',
 		collect(monitor) {

--- a/app/[locale]/logic/logic-editor.context.tsx
+++ b/app/[locale]/logic/logic-editor.context.tsx
@@ -96,7 +96,7 @@ export const useLogicEditor = () => {
 const proOptions: ProOptions = { hideAttribution: true };
 
 export function LogicEditorProvider({ children }: { children: React.ReactNode }) {
-	const [loading, setLoading] = useState(true);
+	const [loading, setLoading] = useState(false);
 	const [name, setName] = useState('');
 	const [nodes, setNodes] = useState<Node[]>(initialNodes);
 	const [edges, setEdges] = useState<Edge[]>([]);
@@ -114,7 +114,7 @@ export function LogicEditorProvider({ children }: { children: React.ReactNode })
 	const ref = useRef<HTMLDivElement>(null);
 	const viewport = useViewport();
 
-	const { generateRandomName, saved, readLogicFromLocalStorageByName, writeLogicToLocalStorage, addNewFile } = useLogicFile();
+	const { readLogicFromLocalStorageByName, writeLogicToLocalStorage } = useLogicFile();
 
 	const [debouncedNodes] = useDebounceValue(nodes, 1000);
 	const [debouncedEdges] = useDebounceValue(edges, 1000);

--- a/components/button/remove.button.tsx
+++ b/components/button/remove.button.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { VariantProps, cva } from 'class-variance-authority';
 import React from 'react';
 
@@ -12,7 +10,6 @@ import {
 	AlertDialogContent,
 	AlertDialogDescription,
 	AlertDialogFooter,
-	AlertDialogHeader,
 	AlertDialogTitle,
 	AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
@@ -48,12 +45,10 @@ export default function RemoveButton({ className, variant, isLoading, descriptio
 				{variant === 'command' && <Tran text="remove" />}
 			</AlertDialogTrigger>
 			<AlertDialogContent>
-				<AlertDialogHeader>
-					<AlertDialogTitle>
-						<Tran text="remove.confirm" />
-					</AlertDialogTitle>
-					<AlertDialogDescription>{description}</AlertDialogDescription>
-				</AlertDialogHeader>
+				<AlertDialogTitle>
+					<Tran text="remove.confirm" />
+				</AlertDialogTitle>
+				<AlertDialogDescription>{description}</AlertDialogDescription>
 				<AlertDialogFooter>
 					<AlertDialogCancel>
 						<Tran text="cancel" />

--- a/components/common/scroll-container.tsx
+++ b/components/common/scroll-container.tsx
@@ -7,79 +7,54 @@ import { cn } from '@/lib/utils';
 
 type AdditionalPadding = `pr-${number}`;
 type Props = {
-  id?: string;
-  className?: string;
-  additionalPadding?: AdditionalPadding;
-  children: ReactNode;
+	id?: string;
+	className?: string;
+	additionalPadding?: AdditionalPadding;
+	children: ReactNode;
 };
 
-const ScrollContainer = React.forwardRef<HTMLDivElement, Props>(({ className, id, additionalPadding = 'pr-2', children }, forwardedRef) => {
-  const pathname = usePathname();
-  const [container, setContainer] = useState<HTMLDivElement | null>(null);
-  const lastScrollTop = React.useRef(0);
-  const [hasGapForScrollbar, setHasGapForScrollbar] = useState(false);
+const ScrollContainer = React.forwardRef<HTMLDivElement, Props>(({ className, id, children }, forwardedRef) => {
+	const pathname = usePathname();
+	const [container, setContainer] = useState<HTMLDivElement | null>(null);
+	const lastScrollTop = React.useRef(0);
 
-  useEffect(() => {
-    if (container === null) return;
+	useEffect(() => {
+		if (container === null) return;
 
-    setHasGapForScrollbar(container.scrollHeight > container.clientHeight);
+		const scrollTop = sessionStorage.getItem(`scroll-top-${pathname}-${id}`);
+		try {
+			if (scrollTop) {
+				container.scrollTop = parseInt(scrollTop);
+			} else {
+				container.scrollTop = lastScrollTop.current;
+			}
+		} catch (error) {
+			console.error(error);
+		}
+	}, [container, pathname, id]);
 
-    function handleScroll() {
-      if (container) {
-        setHasGapForScrollbar(container.scrollHeight > container.clientHeight);
-      }
-    }
-
-    const observer = new ResizeObserver(() => {
-      handleScroll();
-    });
-
-    observer.observe(container);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [container, pathname]);
-
-  useEffect(() => {
-    if (container === null) return;
-
-    const scrollTop = sessionStorage.getItem(`scroll-top-${pathname}-${id}`);
-    try {
-      if (scrollTop) {
-        container.scrollTop = parseInt(scrollTop);
-      } else {
-        container.scrollTop = lastScrollTop.current;
-      }
-    } catch (error) {
-      console.error(error);
-    }
-  }, [container, pathname, id]);
-
-  return (
-    <div
-      id={id}
-      className={cn('h-full scroll-container overflow-y-auto w-full', className, {
-        [additionalPadding]: hasGapForScrollbar,
-      })}
-      onScroll={(event) => {
-        lastScrollTop.current = event.currentTarget.scrollTop;
-        sessionStorage.setItem(`scroll-top-${pathname}-${id}`, event.currentTarget.scrollTop.toString());
-      }}
-      ref={(current) => {
-        if (typeof forwardedRef === 'function') {
-          forwardedRef(current);
-          setContainer(current);
-        } else if (forwardedRef !== null) {
-          forwardedRef.current = current;
-        } else {
-          setContainer(current);
-        }
-      }}
-    >
-      {children}
-    </div>
-  );
+	return (
+		<div
+			id={id}
+			className={cn('h-full scroll-container overflow-y-auto w-full', className)}
+			onScroll={(event) => {
+				lastScrollTop.current = event.currentTarget.scrollTop;
+				sessionStorage.setItem(`scroll-top-${pathname}-${id}`, event.currentTarget.scrollTop.toString());
+			}}
+			ref={(current) => {
+				if (typeof forwardedRef === 'function') {
+					forwardedRef(current);
+					setContainer(current);
+				} else if (forwardedRef !== null) {
+					forwardedRef.current = current;
+				} else {
+					setContainer(current);
+				}
+			}}
+		>
+			{children}
+		</div>
+	);
 });
 
 ScrollContainer.displayName = 'ScrollContainer';

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -19,7 +19,7 @@ const AlertDialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
 	<AlertDialogPrimitive.Overlay
 		className={cn(
-			'fixed inset-0 z-50 bg-black/90 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+			'fixed inset-0 z-10 bg-black/90 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
 			className,
 		)}
 		{...props}
@@ -33,7 +33,6 @@ const AlertDialogContent = React.forwardRef<
 	React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
 >(({ className, ...props }, ref) => (
 	<AlertDialogPortal>
-		<AlertDialogOverlay className="z-40" />
 		<AlertDialogPrimitive.Content
 			ref={ref}
 			className={cn(

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -13,50 +13,95 @@ const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
 
 const AlertDialogPortal = AlertDialogPrimitive.Portal;
 
-const AlertDialogOverlay = React.forwardRef<React.ElementRef<typeof AlertDialogPrimitive.Overlay>, React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>>(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Overlay className={cn('fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0', className)} {...props} ref={ref} />
+const AlertDialogOverlay = React.forwardRef<
+	React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+	React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+	<AlertDialogPrimitive.Overlay
+		className={cn(
+			'fixed inset-0 z-50 bg-black/90 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+			className,
+		)}
+		{...props}
+		ref={ref}
+	/>
 ));
 AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
 
-const AlertDialogContent = React.forwardRef<React.ElementRef<typeof AlertDialogPrimitive.Content>, React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>>(({ className, ...props }, ref) => (
-  <AlertDialogPortal>
-    <AlertDialogOverlay />
-    <AlertDialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-4/5 max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-md border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
-        className,
-      )}
-      {...props}
-    />
-  </AlertDialogPortal>
+const AlertDialogContent = React.forwardRef<
+	React.ElementRef<typeof AlertDialogPrimitive.Content>,
+	React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+	<AlertDialogPortal>
+		<AlertDialogOverlay className="z-40" />
+		<AlertDialogPrimitive.Content
+			ref={ref}
+			className={cn(
+				'fixed left-[50%] top-[50%] z-50 grid w-4/5 max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-md border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+				className,
+			)}
+			{...props}
+		/>
+	</AlertDialogPortal>
 ));
 AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
 
-const AlertDialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div className={cn('flex flex-col space-y-2 text-center sm:text-left', className)} {...props} />;
+const AlertDialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+	<div className={cn('flex flex-col space-y-2 text-center sm:text-left', className)} {...props} />
+);
 AlertDialogHeader.displayName = 'AlertDialogHeader';
 
-const AlertDialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div className={cn('flex flex-col gap-2  md:flex-row md:items-center md:justify-end', className)} {...props} />;
+const AlertDialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+	<div className={cn('flex flex-col gap-2  md:flex-row md:items-center md:justify-end', className)} {...props} />
+);
 AlertDialogFooter.displayName = 'AlertDialogFooter';
 
-const AlertDialogTitle = React.forwardRef<React.ElementRef<typeof AlertDialogPrimitive.Title>, React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>>(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Title ref={ref} className={cn('text-lg font-semibold', className)} {...props} />
+const AlertDialogTitle = React.forwardRef<
+	React.ElementRef<typeof AlertDialogPrimitive.Title>,
+	React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+	<AlertDialogPrimitive.Title ref={ref} className={cn('text-lg font-semibold', className)} {...props} />
 ));
 AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
 
-const AlertDialogDescription = React.forwardRef<React.ElementRef<typeof AlertDialogPrimitive.Description>, React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>>(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Description ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+const AlertDialogDescription = React.forwardRef<
+	React.ElementRef<typeof AlertDialogPrimitive.Description>,
+	React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+	<AlertDialogPrimitive.Description ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
 ));
 AlertDialogDescription.displayName = AlertDialogPrimitive.Description.displayName;
 
-const AlertDialogAction = React.forwardRef<React.ElementRef<typeof AlertDialogPrimitive.Action>, React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action> & VariantProps<typeof buttonVariants>>(
-  ({ className, variant, size, ...props }, ref) => <AlertDialogPrimitive.Action ref={ref} className={cn(buttonVariants({ variant, size, className }))} {...props} />,
-);
+const AlertDialogAction = React.forwardRef<
+	React.ElementRef<typeof AlertDialogPrimitive.Action>,
+	React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action> & VariantProps<typeof buttonVariants>
+>(({ className, variant, size, ...props }, ref) => (
+	<AlertDialogPrimitive.Action ref={ref} className={cn(buttonVariants({ variant, size, className }))} {...props} />
+));
 AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
 
-const AlertDialogCancel = React.forwardRef<React.ElementRef<typeof AlertDialogPrimitive.Cancel>, React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>>(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Cancel ref={ref} className={cn(buttonVariants({ variant: 'outline' }), 'sm:mt-0', className)} {...props} />
+const AlertDialogCancel = React.forwardRef<
+	React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+	React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+	<AlertDialogPrimitive.Cancel
+		ref={ref}
+		className={cn(buttonVariants({ variant: 'outline' }), 'sm:mt-0', className)}
+		{...props}
+	/>
 ));
 AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
 
-export { AlertDialog, AlertDialogPortal, AlertDialogOverlay, AlertDialogTrigger, AlertDialogContent, AlertDialogHeader, AlertDialogFooter, AlertDialogTitle, AlertDialogDescription, AlertDialogAction, AlertDialogCancel };
+export {
+	AlertDialog,
+	AlertDialogPortal,
+	AlertDialogOverlay,
+	AlertDialogTrigger,
+	AlertDialogContent,
+	AlertDialogHeader,
+	AlertDialogFooter,
+	AlertDialogTitle,
+	AlertDialogDescription,
+	AlertDialogAction,
+	AlertDialogCancel,
+};


### PR DESCRIPTION
…e and logic

Remove `hasGapForScrollbar` state and related scrollbar gap logic to streamline the component. The functionality was unnecessary and added complexity without clear benefits.