### PR TITLE
feat(documents): add documents page and related components

### DIFF
--- a/app/[locale]/(main)/admin/documents/create-document-tree.dialog.tsx
+++ b/app/[locale]/(main)/admin/documents/create-document-tree.dialog.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import Tran from '@/components/common/tran';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogTrigger } from '@/components/ui/dialog';
+
+type CreateDocumentTreeDialogProps = {
+	path?: string;
+};
+
+export default function CreateDocumentTreeDialog({ path }: CreateDocumentTreeDialogProps) {
+	return (
+		<Dialog>
+			<DialogTrigger asChild>
+				<Button>
+					<Tran text="documents.create-tree" />
+				</Button>
+			</DialogTrigger>
+		</Dialog>
+	);
+}

--- a/app/[locale]/(main)/admin/documents/page.tsx
+++ b/app/[locale]/(main)/admin/documents/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useState } from 'react';
+
+import CreateDocumentTreeDialog from '@/app/[locale]/(main)/admin/documents/create-document-tree.dialog';
+
+import ComboBox from '@/components/common/combo-box';
+import ErrorMessage from '@/components/common/error-message';
+import LoadingSpinner from '@/components/common/loading-spinner';
+import ScrollContainer from '@/components/common/scroll-container';
+
+import useClientApi from '@/hooks/use-client';
+import { useI18n } from '@/i18n/client';
+import { Locale, defaultLocale, locales } from '@/i18n/config';
+import { getDocumentByLanguage } from '@/query/document';
+
+import { useQuery } from '@tanstack/react-query';
+
+export default function Page() {
+	const { t } = useI18n(['translation']);
+	const [language, setLanguage] = useState<Locale>(defaultLocale);
+
+	const axios = useClientApi();
+	const { data, isLoading, error } = useQuery({
+		queryKey: ['documents', language],
+		queryFn: () => getDocumentByLanguage(axios, language),
+	});
+
+	if (error) {
+		return <ErrorMessage error={error} />;
+	}
+
+	return (
+		<div className="f-full h-full flex flex-col overflow-hidden divide-y">
+			<div className="p-2 flex w-full justify-between">
+				<ComboBox<Locale>
+					className="h-10"
+					searchBar={false}
+					value={{ label: t(language ?? 'en'), value: language ?? ('en' as Locale) }}
+					values={locales.map((locale) => ({
+						label: t(locale),
+						value: locale,
+					}))}
+					onChange={(language) => setLanguage(language ?? 'en')}
+				/>
+				<CreateDocumentTreeDialog />
+			</div>
+			<ScrollContainer className="p-2">{isLoading && <LoadingSpinner />}</ScrollContainer>
+		</div>
+	);
+}

--- a/app/[locale]/(main)/routes.tsx
+++ b/app/[locale]/(main)/routes.tsx
@@ -1,5 +1,7 @@
 import { ReactNode } from 'react';
 
+
+
 import { ChatIconPath } from '@/app/[locale]/(main)/chat-icon-path';
 import { MapPath } from '@/app/[locale]/(main)/map-path';
 import { PluginPath } from '@/app/[locale]/(main)/plugin-path';
@@ -8,33 +10,16 @@ import { SchematicPath } from '@/app/[locale]/(main)/schematic-path';
 import { TranslationPathIcon } from '@/app/[locale]/(main)/translation-path-icon';
 import { VerifyPathIcon } from '@/app/[locale]/(main)/verify-path-icon';
 
-import {
-  AnalyticIcon,
-  BoxIcon,
-  ChartIcon,
-  CmdIcon,
-  CommentIcon,
-  CrownIcon,
-  DocsIcon,
-  DocumentIcon,
-  FileIcon,
-  HomeIcon,
-  ImageIcon,
-  LogIcon,
-  LoginIcon,
-  MapIcon,
-  MindustryGptIcon,
-  PluginIcon,
-  PostIcon,
-  RatioIcon,
-  SchematicIcon,
-  ServerIcon,
-  UploadIcon,
-} from '@/components/common/icons';
+
+
+import { AnalyticIcon, BoxIcon, ChartIcon, CmdIcon, CommentIcon, CrownIcon, DocsIcon, DocumentIcon, FileIcon, HomeIcon, ImageIcon, LogIcon, LoginIcon, MapIcon, MindustryGptIcon, PluginIcon, PostIcon, RatioIcon, SchematicIcon, ServerIcon, UploadIcon } from '@/components/common/icons';
 import Tran from '@/components/common/tran';
+
+
 
 import { locales } from '@/i18n/config';
 import { Filter } from '@/lib/utils';
+
 
 const localesRegex = `/(${locales.join('|')})`;
 
@@ -70,256 +55,278 @@ export type Path = {
 );
 
 export const groups: readonly PathGroup[] = [
-  {
-    key: 'user',
-    name: '',
-    paths: [
-      {
-        id: 'home',
-        path: '/',
-        name: <Tran asChild text="home" />,
-        icon: <HomeIcon />,
-        regex: [`^${localesRegex}$`],
-      },
-      {
-        id: 'schematics',
-        path: '/schematics',
-        name: <Tran asChild text="schematic" />,
-        icon: <SchematicIcon />,
-        regex: [`^${localesRegex}/schematics`],
-      },
-      {
-        id: 'maps',
-        path: '/maps',
-        name: <Tran asChild text="map" />,
-        icon: <MapIcon />,
-        regex: [`^${localesRegex}/maps`],
-      },
-      {
-        id: 'servers',
-        path: '/servers',
-        name: <Tran asChild text="server" />,
-        icon: <ServerIcon />,
-        regex: [`^${localesRegex}/servers`],
-      },
-      {
-        id: 'plugins',
-        path: '/plugins',
-        name: <Tran asChild text="plugin" />,
-        icon: <PluginIcon />,
-        regex: [`^${localesRegex}/plugins`],
-      },
-      {
-        id: 'posts',
-        path: '/posts',
-        name: <Tran asChild text="post" />,
-        icon: <PostIcon />,
-        regex: [`^${localesRegex}/posts`],
-      },
-      {
-        id: 'docs',
-        path: '/docs',
-        name: <Tran asChild text="docs" />,
-        icon: <DocsIcon />,
-        regex: [`^${localesRegex}/docs`],
-      },
-      {
-        id: 'chat',
-        path: '/chat',
-        name: <Tran asChild text="chat" />,
-        icon: <ChatIconPath />,
-        regex: [`^${localesRegex}/chat`],
-      },
-      {
-        id: 'mindustry-gpt',
-        path: '/mindustry-gpt',
-        name: <Tran asChild text="mindustry-gpt" />,
-        icon: <MindustryGptIcon />,
-        regex: [`^${localesRegex}/mindustry-gpt$`],
-      },
-      {
-        id: 'rank',
-        path: '/rank',
-        name: <Tran asChild text="rank" />,
-        icon: <CrownIcon />,
-        regex: [`^${localesRegex}/rank`],
-      },
-      {
-        id: 'ratio',
-        path: 'https://mindustry-calculator.vercel.app/',
-        name: <Tran asChild text="ratio" />,
-        icon: <RatioIcon />,
-        regex: [`^${localesRegex}/ratio`],
-      },
-      {
-        id: 'logic',
-        path: '/logic',
-        name: <Tran asChild text="logic" />,
-        icon: <CmdIcon />,
-        regex: [`^${localesRegex}/logic`],
-      },
-      {
-        id: '/image-generator',
-        name: <Tran asChild text="image-generator" />,
-        icon: <ImageIcon className="size-4" />,
-        regex: [`^${localesRegex}/image-generator`],
-        path: [
-          {
-            id: 'logic',
-            path: '/image-generator/logic',
-            name: <Tran asChild text="image-logic-generator" />,
-            icon: <LoginIcon />,
-            regex: [`^${localesRegex}/image-generator/logic$`],
-          },
-          {
-            id: 'router',
-            path: '/image-generator/router',
-            name: <Tran asChild text="image-sorter-generator" />,
-            icon: <LoginIcon />,
-            regex: [`^${localesRegex}/image-generator/sorter$`],
-          },
-          {
-            id: 'canvas',
-            path: '/image-generator/canvas',
-            name: <Tran asChild text="image-canvas-generator" />,
-            icon: <LoginIcon />,
-            regex: [`^${localesRegex}/image-generator/canvas$`],
-          },
-          {
-            id: 'map',
-            path: '/image-generator/map',
-            name: <Tran asChild text="image-map-generator" />,
-            icon: <LoginIcon />,
-            regex: [`^${localesRegex}/image-generator/map$`],
-          },
-        ],
-      },
-    ],
-  },
-  {
-    key: 'admin',
-    name: <Tran className="font-semibold" text="admin" />,
-    paths: [
-      {
-        id: 'admin',
-        path: '/admin',
-        name: <Tran asChild text="dashboard" />,
-        icon: <ChartIcon />,
-        filter: { authority: 'VIEW_DASH_BOARD' },
-        regex: [`^${localesRegex}/admin$`],
-      },
-      {
-        id: 'admin-setting',
-        path: '/admin/setting',
-        name: <Tran asChild text="setting" />,
-        icon: <BoxIcon />,
-        filter: { any: [{ authority: 'EDIT_USER_ROLE' }, { authority: 'EDIT_USER_AUTHORITY' }, { authority: 'MANAGE_TAG' }, { authority: 'VIEW_SETTING' }] },
-        regex: [`^${localesRegex}/admin/setting`],
-      },
-      {
-        id: 'logs',
-        path: '/logs',
-        name: <Tran asChild text="log" />,
-        icon: <LogIcon />,
-        filter: { authority: 'VIEW_LOG' },
-        regex: [`^${localesRegex}/logs$`],
-      },
-      {
-        id: 'admin-comments',
-        path: '/admin/comments',
-        name: <Tran asChild text="comment" />,
-        icon: <CommentIcon />,
-        filter: { authority: 'MANAGE_COMMENT' },
-        regex: [`^${localesRegex}/admin/comments$`],
-      },
-      {
-        id: 'verify',
-        name: <Tran asChild text="verify" />,
-        regex: [`^${localesRegex}/admin/(schematics|maps|posts|plugins)`],
-        path: [
-          {
-            id: 'admin-schematics',
-            name: <SchematicPath />,
-            path: '/admin/schematics',
-            icon: <SchematicIcon />,
-            filter: { authority: 'VERIFY_SCHEMATIC' },
-            regex: [`^${localesRegex}/admin/schematics`],
-          },
-          {
-            id: 'admin-maps',
-            name: <MapPath />,
-            path: '/admin/maps',
-            icon: <MapIcon />,
-            filter: { authority: 'VERIFY_MAP' },
-            regex: [`^${localesRegex}/admin/maps`],
-          },
-          {
-            id: 'admin-posts',
-            name: <PostPath />,
-            path: '/admin/posts',
-            icon: <PostIcon />,
-            filter: { authority: 'VERIFY_POST' },
-            regex: [`^${localesRegex}/admin/posts`],
-          },
-          {
-            id: 'admin-plugins',
-            name: <PluginPath />,
-            path: '/admin/plugins',
-            icon: <PluginIcon />,
-            filter: { authority: 'VERIFY_PLUGIN' },
-            regex: [`^${localesRegex}/admin/plugins`],
-          },
-        ],
-        icon: <VerifyPathIcon />,
-      },
-      {
-        id: 'translation',
-        path: '/translation',
-        name: <Tran asChild text="translation" />,
-        icon: <TranslationPathIcon />,
-        filter: { authority: 'VIEW_TRANSLATION' },
-        regex: [`^${localesRegex}/translation`],
-      },
-      {
-        id: 'files',
-        path: '/files',
-        name: <Tran asChild text="file" />,
-        icon: <FileIcon />,
-        filter: { authority: 'VIEW_FILE' },
-        regex: [`^${localesRegex}/files$`],
-      },
-      {
-        id: 'upload-admin',
-        path: '/upload/admin',
-        name: <Tran asChild text="upload" />,
-        icon: <UploadIcon />,
-        filter: { authority: 'VIEW_FILE' },
-        regex: [`^${localesRegex}/upload/admin$`],
-      },
-      {
-        id: 'analytic',
-        path: 'https://analytic.mindustry-tool.com',
-        name: <Tran asChild text="analytic" />,
-        icon: <AnalyticIcon />,
-        filter: { authority: 'VIEW_DASH_BOARD' },
-        regex: [`^${localesRegex}/analytic`],
-      },
-      {
-        id: 'mindustry-gpt-documents',
-        name: 'MindustryGPT',
-        icon: <MindustryGptIcon />,
-        filter: { authority: 'VIEW_DOCUMENT' },
-        regex: [`^${localesRegex}/mindustry-gpt`],
-        path: [
-          {
-            id: 'mindustry-gpt-documents',
-            name: 'Document',
-            path: '/mindustry-gpt/documents',
-            icon: <DocumentIcon />,
-            regex: [`^${localesRegex}/mindustry-gpt/documents`],
-          },
-        ],
-      },
-    ],
-  },
+	{
+		key: 'user',
+		name: '',
+		paths: [
+			{
+				id: 'home',
+				path: '/',
+				name: <Tran asChild text="home" />,
+				icon: <HomeIcon />,
+				regex: [`^${localesRegex}$`],
+			},
+			{
+				id: 'schematics',
+				path: '/schematics',
+				name: <Tran asChild text="schematic" />,
+				icon: <SchematicIcon />,
+				regex: [`^${localesRegex}/schematics`],
+			},
+			{
+				id: 'maps',
+				path: '/maps',
+				name: <Tran asChild text="map" />,
+				icon: <MapIcon />,
+				regex: [`^${localesRegex}/maps`],
+			},
+			{
+				id: 'servers',
+				path: '/servers',
+				name: <Tran asChild text="server" />,
+				icon: <ServerIcon />,
+				regex: [`^${localesRegex}/servers`],
+			},
+			{
+				id: 'plugins',
+				path: '/plugins',
+				name: <Tran asChild text="plugin" />,
+				icon: <PluginIcon />,
+				regex: [`^${localesRegex}/plugins`],
+			},
+			{
+				id: 'posts',
+				path: '/posts',
+				name: <Tran asChild text="post" />,
+				icon: <PostIcon />,
+				regex: [`^${localesRegex}/posts`],
+			},
+			{
+				id: 'docs',
+				path: '/docs',
+				name: <Tran asChild text="docs" />,
+				icon: <DocsIcon />,
+				regex: [`^${localesRegex}/docs`],
+			},
+			{
+				id: 'documents',
+				path: '/documents',
+				name: <Tran asChild text="documents" />,
+				icon: <DocsIcon />,
+				regex: [`^${localesRegex}/documents`],
+			},
+			{
+				id: 'chat',
+				path: '/chat',
+				name: <Tran asChild text="chat" />,
+				icon: <ChatIconPath />,
+				regex: [`^${localesRegex}/chat`],
+			},
+			{
+				id: 'mindustry-gpt',
+				path: '/mindustry-gpt',
+				name: <Tran asChild text="mindustry-gpt" />,
+				icon: <MindustryGptIcon />,
+				regex: [`^${localesRegex}/mindustry-gpt$`],
+			},
+			{
+				id: 'rank',
+				path: '/rank',
+				name: <Tran asChild text="rank" />,
+				icon: <CrownIcon />,
+				regex: [`^${localesRegex}/rank`],
+			},
+			{
+				id: 'ratio',
+				path: 'https://mindustry-calculator.vercel.app/',
+				name: <Tran asChild text="ratio" />,
+				icon: <RatioIcon />,
+				regex: [`^${localesRegex}/ratio`],
+			},
+			{
+				id: 'logic',
+				path: '/logic',
+				name: <Tran asChild text="logic" />,
+				icon: <CmdIcon />,
+				regex: [`^${localesRegex}/logic`],
+			},
+			{
+				id: '/image-generator',
+				name: <Tran asChild text="image-generator" />,
+				icon: <ImageIcon className="size-4" />,
+				regex: [`^${localesRegex}/image-generator`],
+				path: [
+					{
+						id: 'logic',
+						path: '/image-generator/logic',
+						name: <Tran asChild text="image-logic-generator" />,
+						icon: <LoginIcon />,
+						regex: [`^${localesRegex}/image-generator/logic$`],
+					},
+					{
+						id: 'router',
+						path: '/image-generator/router',
+						name: <Tran asChild text="image-sorter-generator" />,
+						icon: <LoginIcon />,
+						regex: [`^${localesRegex}/image-generator/sorter$`],
+					},
+					{
+						id: 'canvas',
+						path: '/image-generator/canvas',
+						name: <Tran asChild text="image-canvas-generator" />,
+						icon: <LoginIcon />,
+						regex: [`^${localesRegex}/image-generator/canvas$`],
+					},
+					{
+						id: 'map',
+						path: '/image-generator/map',
+						name: <Tran asChild text="image-map-generator" />,
+						icon: <LoginIcon />,
+						regex: [`^${localesRegex}/image-generator/map$`],
+					},
+				],
+			},
+		],
+	},
+	{
+		key: 'admin',
+		name: <Tran className="font-semibold" text="admin" />,
+		paths: [
+			{
+				id: 'admin',
+				path: '/admin',
+				name: <Tran asChild text="dashboard" />,
+				icon: <ChartIcon />,
+				filter: { authority: 'VIEW_DASH_BOARD' },
+				regex: [`^${localesRegex}/admin$`],
+			},
+			{
+				id: 'admin-setting',
+				path: '/admin/setting',
+				name: <Tran asChild text="setting" />,
+				icon: <BoxIcon />,
+				filter: {
+					any: [
+						{ authority: 'EDIT_USER_ROLE' },
+						{ authority: 'EDIT_USER_AUTHORITY' },
+						{ authority: 'MANAGE_TAG' },
+						{ authority: 'VIEW_SETTING' },
+					],
+				},
+				regex: [`^${localesRegex}/admin/setting`],
+			},
+			{
+				id: 'logs',
+				path: '/logs',
+				name: <Tran asChild text="log" />,
+				icon: <LogIcon />,
+				filter: { authority: 'VIEW_LOG' },
+				regex: [`^${localesRegex}/logs$`],
+			},
+			{
+				id: 'admin-comments',
+				path: '/admin/comments',
+				name: <Tran asChild text="comment" />,
+				icon: <CommentIcon />,
+				filter: { authority: 'MANAGE_COMMENT' },
+				regex: [`^${localesRegex}/admin/comments$`],
+			},
+			{
+				id: 'verify',
+				name: <Tran asChild text="verify" />,
+				regex: [`^${localesRegex}/admin/(schematics|maps|posts|plugins)`],
+				path: [
+					{
+						id: 'admin-schematics',
+						name: <SchematicPath />,
+						path: '/admin/schematics',
+						icon: <SchematicIcon />,
+						filter: { authority: 'VERIFY_SCHEMATIC' },
+						regex: [`^${localesRegex}/admin/schematics`],
+					},
+					{
+						id: 'admin-maps',
+						name: <MapPath />,
+						path: '/admin/maps',
+						icon: <MapIcon />,
+						filter: { authority: 'VERIFY_MAP' },
+						regex: [`^${localesRegex}/admin/maps`],
+					},
+					{
+						id: 'admin-posts',
+						name: <PostPath />,
+						path: '/admin/posts',
+						icon: <PostIcon />,
+						filter: { authority: 'VERIFY_POST' },
+						regex: [`^${localesRegex}/admin/posts`],
+					},
+					{
+						id: 'admin-plugins',
+						name: <PluginPath />,
+						path: '/admin/plugins',
+						icon: <PluginIcon />,
+						filter: { authority: 'VERIFY_PLUGIN' },
+						regex: [`^${localesRegex}/admin/plugins`],
+					},
+				],
+				icon: <VerifyPathIcon />,
+			},
+			{
+				id: 'translation',
+				path: '/translation',
+				name: <Tran asChild text="translation" />,
+				icon: <TranslationPathIcon />,
+				filter: { authority: 'VIEW_TRANSLATION' },
+				regex: [`^${localesRegex}/translation`],
+			},
+			{
+				id: 'files',
+				path: '/files',
+				name: <Tran asChild text="file" />,
+				icon: <FileIcon />,
+				filter: { authority: 'VIEW_FILE' },
+				regex: [`^${localesRegex}/files$`],
+			},
+			{
+				id: 'upload-admin',
+				path: '/upload/admin',
+				name: <Tran asChild text="upload" />,
+				icon: <UploadIcon />,
+				filter: { authority: 'VIEW_FILE' },
+				regex: [`^${localesRegex}/upload/admin$`],
+			},
+			{
+				id: 'analytic',
+				path: 'https://analytic.mindustry-tool.com',
+				name: <Tran asChild text="analytic" />,
+				icon: <AnalyticIcon />,
+				filter: { authority: 'VIEW_DASH_BOARD' },
+				regex: [`^${localesRegex}/analytic`],
+			},
+      
+			{
+				id: 'admin-documents',
+				path: '/admin/documents',
+				name: <Tran asChild text="documents" />,
+				icon: <DocsIcon />,
+				regex: [`^${localesRegex}/admin/documents`],
+			},
+			{
+				id: 'mindustry-gpt-documents',
+				name: 'MindustryGPT',
+				icon: <MindustryGptIcon />,
+				filter: { authority: 'VIEW_DOCUMENT' },
+				regex: [`^${localesRegex}/mindustry-gpt`],
+				path: [
+					{
+						id: 'mindustry-gpt-documents',
+						name: 'Document',
+						path: '/mindustry-gpt/documents',
+						icon: <DocumentIcon />,
+						regex: [`^${localesRegex}/mindustry-gpt/documents`],
+					},
+				],
+			},
+		],
+	},
 ];

--- a/app/[locale]/(main)/upload/admin/page.tsx
+++ b/app/[locale]/(main)/upload/admin/page.tsx
@@ -22,7 +22,10 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 const fetchFiles = async (axios: AxiosInstance, state: UploadState) => {
 	const { data } = await axios.get('/upload', { params: { state } });
-	return data as string[];
+	return data as {
+		path: string;
+		message: string;
+	}[];
 };
 
 const uploadFile = async (
@@ -189,9 +192,12 @@ function List({ state }: { state: UploadState }) {
 				{isFetching && <LoadingSpinner className="m-0" />}
 			</h3>
 			<div className="w-full space-y-1">
-				{data?.map((path) => (
+				{data?.map(({ path, message }) => (
 					<div className="rounded-md border p-2 bg-card flex justify-between items-center" key={path}>
-						<span>{path}</span>
+						<div className="grid">
+							<span>{path}</span>
+							<span className="text-muted-foreground text-xs">{message}</span>
+						</div>
 						<Button
 							variant="destructive"
 							onClick={() => {

--- a/app/[locale]/documents/page.tsx
+++ b/app/[locale]/documents/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+	return (
+		<div>
+			<h1>Hello World</h1>
+		</div>
+	);
+}

--- a/app/[locale]/logic/search.panel.tsx
+++ b/app/[locale]/logic/search.panel.tsx
@@ -117,7 +117,7 @@ export default function SearchPanel() {
 									<div key={index}>
 										<span className="text-foreground">{label}: </span>
 										{value.substring(0, value.indexOf(debouncedFilter))}
-										<span className="underline">{debouncedFilter}</span>
+										<span className="underline bg-brand/50">{debouncedFilter}</span>
 										{value.substring(value.indexOf(debouncedFilter) + debouncedFilter.length)}
 									</div>
 								))}

--- a/query/document.ts
+++ b/query/document.ts
@@ -1,7 +1,9 @@
 import { AxiosInstance } from 'axios';
 
+import { Locale } from '@/i18n/config';
 import { CreateDocumentRequest } from '@/types/request/CreateDocumentRequest';
 import { Document } from '@/types/response/Document';
+import { DocumentDto } from '@/types/response/DocumentDto';
 import { DocumentPaginationQuery } from '@/types/schema/search-query';
 
 export async function deleteDocument(axios: AxiosInstance, id: string): Promise<void> {
@@ -23,3 +25,10 @@ export default async function createDocument(axios: AxiosInstance, data: CreateD
 		data,
 	});
 }
+
+export async function getDocumentByLanguage(axios: AxiosInstance, language: Locale) {
+	const result = await axios.get(`/documents/${language}`);
+
+	return result.data as DocumentDto[];
+}
+

--- a/types/response/DocumentDto.ts
+++ b/types/response/DocumentDto.ts
@@ -1,0 +1,13 @@
+import { Locale } from "@/i18n/config";
+
+export type DocumentDto = {
+	id: string;
+	path: string;
+	userId: string;
+	itemId: string;
+	treeId: string;
+	title: string;
+	language: Locale;
+	updatedAt: string;
+	createdAt: string;
+};


### PR DESCRIPTION
This commit introduces a new documents page and its related components, including the `DocumentDto` type, `CreateDocumentTreeDialog`, and the main documents page under the admin section. Additionally, it adds a new route for documents in the main routes configuration and enhances the search panel with a background highlight for the filter term.