### PR TITLE
feat(users): add support for multiple images in user metadata

### DIFF
--- a/app/[locale]/(main)/users/[id]/page.tsx
+++ b/app/[locale]/(main)/users/[id]/page.tsx
@@ -26,12 +26,22 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 		return { title: 'Error' };
 	}
 
-	const { name, imageUrl, roles, stats } = user;
+	const { name, imageUrl, roles, stats, thumbnail } = user;
 
 	const description = {
 		roles: roles.map((role) => role.name).join(', '),
 		stats,
 	};
+
+	const images = [];
+
+	if (thumbnail) {
+		images.push(thumbnail);
+	}
+
+	if (imageUrl) {
+		images.push(imageUrl);
+	}
 
 	return {
 		title: formatTitle(name),
@@ -39,7 +49,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 		openGraph: {
 			title: name,
 			description: roles.map((role) => role.name).join(', '),
-			images: imageUrl ?? '',
+			images,
 		},
 		alternates: generateAlternate(`/users/${id}`),
 	};

--- a/components/user/user-avatar.tsx
+++ b/components/user/user-avatar.tsx
@@ -131,7 +131,7 @@ function AvatarImage({ className, user: { imageUrl, name } }: AvatarImageProps) 
 
   return (
     <div className={cn('flex size-8 min-h-8 min-w-8 items-center aspect-square justify-center overflow-hidden rounded-full border border-border capitalize', className)}>
-      <Image className={cn('h-full w-full object-cover', className)} height={32} width={32} src={imageUrl + '?size=32'} alt={username} priority onError={() => setError(true)} />
+      <Image className={cn('h-full w-full object-cover', className)} height={32} width={32} src={imageUrl + '?size=128'} alt={username} priority onError={() => setError(true)} />
     </div>
   );
 }


### PR DESCRIPTION
Enhance the user metadata generation to support multiple images by including both `thumbnail` and `imageUrl` in the `openGraph` images array. This improves the display of user profiles by providing more visual context.