### PR TITLE
refactor(components): extract size display logic into reusable SizeCa…

### DIFF
--- a/components/common/size-card.tsx
+++ b/components/common/size-card.tsx
@@ -1,0 +1,9 @@
+import Tran from '@/components/common/tran';
+
+export default function SizeCard({ size: { width, height } }: { size: { width: number; height: number } }) {
+	return (
+		<span>
+			<Tran text="size" /> {width}x{height} ({width * height})
+		</span>
+	);
+}

--- a/components/map/map-detail-card.tsx
+++ b/components/map/map-detail-card.tsx
@@ -19,7 +19,7 @@ import {
 } from '@/components/common/detail';
 import DetailSwipeToNavigate from '@/components/common/detail-swipe-to-navigate';
 import { ShareIcon } from '@/components/common/icons';
-import Tran from '@/components/common/tran';
+import SizeCard from '@/components/common/size-card';
 import LikeAndDislike from '@/components/like/like-and-dislike';
 import { DeleteMapButton } from '@/components/map/delete-map.button';
 import { TakeDownMapButton } from '@/components/map/take-down-map.button';
@@ -29,9 +29,9 @@ import IdUserCard from '@/components/user/id-user-card';
 import env from '@/constant/env';
 import { useSession } from '@/context/session.context';
 import ProtectedElement from '@/layout/protected-element';
+import { getMaps } from '@/query/map';
 import { MapDetail } from '@/types/response/MapDetail';
 import { ItemPaginationQuery } from '@/types/schema/search-query';
-import { getMaps } from '@/query/map';
 
 type MapDetailCardProps = {
 	map: MapDetail;
@@ -62,9 +62,7 @@ export default function MapDetailCard({
 							<DetailTitle>{name}</DetailTitle>
 							<IdUserCard id={userId} />
 							<Verifier verifierId={verifierId} />
-							<span>
-								<Tran text="size" /> {width}x{height}
-							</span>
+							<SizeCard size={{ width, height }} />
 							<DetailDescription>{description}</DetailDescription>
 							<DetailTagsCard tags={tags} type="map" />
 						</DetailHeader>

--- a/components/map/upload-map-detail-card.tsx
+++ b/components/map/upload-map-detail-card.tsx
@@ -5,9 +5,17 @@ import React, { useState } from 'react';
 
 import CopyButton from '@/components/button/copy.button';
 import DownloadButton from '@/components/button/download.button';
-import { Detail, DetailActions, DetailContent, DetailDescription, DetailHeader, DetailImage, DetailInfo, DetailTitle } from '@/components/common/detail';
+import {
+	Detail,
+	DetailActions,
+	DetailContent,
+	DetailDescription,
+	DetailHeader,
+	DetailImage,
+	DetailInfo,
+	DetailTitle,
+} from '@/components/common/detail';
 import { ShareIcon } from '@/components/common/icons';
-import Tran from '@/components/common/tran';
 import { DeleteMapButton } from '@/components/map/delete-map.button';
 import VerifyMapButton from '@/components/map/verify-map.button';
 import TagSelector from '@/components/search/tag-selector';
@@ -16,12 +24,15 @@ import IdUserCard from '@/components/user/id-user-card';
 import env from '@/constant/env';
 import { MapDetail } from '@/types/response/MapDetail';
 import TagGroup, { TagGroups } from '@/types/response/TagGroup';
+import SizeCard from '@/components/common/size-card';
 
 type UploadMapDetailCardProps = {
 	map: MapDetail;
 };
 
-export default function UploadMapDetailCard({ map: { id, name, tags, description, userId, width, height } }: UploadMapDetailCardProps) {
+export default function UploadMapDetailCard({
+	map: { id, name, tags, description, userId, width, height },
+}: UploadMapDetailCardProps) {
 	const [selectedTags, setSelectedTags] = useState<TagGroup[]>(TagGroups.parsTagDto(tags));
 
 	const { locale } = useParams();
@@ -43,9 +54,7 @@ export default function UploadMapDetailCard({ map: { id, name, tags, description
 					<DetailHeader>
 						<DetailTitle>{name}</DetailTitle>
 						<IdUserCard id={userId} />
-						<span>
-							<Tran text="size" /> {width}x{height}
-						</span>
+						<SizeCard size={{ width, height }} />
 						<DetailDescription>{description}</DetailDescription>
 						<TagSelector type="map" value={selectedTags} onChange={setSelectedTags} />
 					</DetailHeader>

--- a/components/schematic/schematic-detail-card.tsx
+++ b/components/schematic/schematic-detail-card.tsx
@@ -34,6 +34,7 @@ import ProtectedElement from '@/layout/protected-element';
 import { getSchematicData, getSchematics } from '@/query/schematic';
 import { SchematicDetail } from '@/types/response/SchematicDetail';
 import { ItemPaginationQuery } from '@/types/schema/search-query';
+import SizeCard from '@/components/common/size-card';
 
 const DeleteSchematicButton = dynamic(() => import('@/components/schematic/delete-schematic.button'));
 const TakeDownSchematicButton = dynamic(() => import('@/components/schematic/take-down-schematic.button'));
@@ -90,9 +91,7 @@ export default function SchematicDetailCard({
 							<DetailTitle>{name}</DetailTitle>
 							<IdUserCard id={userId} />
 							<Verifier verifierId={verifierId} />
-							<span>
-								<Tran text="size" /> {width}x{height}
-							</span>
+							<SizeCard size={{ width, height }} />
 							<DetailDescription>{description}</DetailDescription>
 							<ItemRequirementCard requirements={requirements} />
 							<DetailTagsCard tags={tags} type="schematic" />

--- a/components/schematic/upload-schematic-detail-card.tsx
+++ b/components/schematic/upload-schematic-detail-card.tsx
@@ -6,7 +6,16 @@ import React, { useState } from 'react';
 
 import CopyButton from '@/components/button/copy.button';
 import DownloadButton from '@/components/button/download.button';
-import { Detail, DetailActions, DetailContent, DetailDescription, DetailHeader, DetailImage, DetailInfo, DetailTitle } from '@/components/common/detail';
+import {
+	Detail,
+	DetailActions,
+	DetailContent,
+	DetailDescription,
+	DetailHeader,
+	DetailImage,
+	DetailInfo,
+	DetailTitle,
+} from '@/components/common/detail';
 import { ShareIcon } from '@/components/common/icons';
 import Tran from '@/components/common/tran';
 import ItemRequirementCard from '@/components/schematic/item-requirement-card';
@@ -20,6 +29,7 @@ import useToastAction from '@/hooks/use-toast-action';
 import { getSchematicData } from '@/query/schematic';
 import { SchematicDetail } from '@/types/response/SchematicDetail';
 import TagGroup, { TagGroups } from '@/types/response/TagGroup';
+import SizeCard from '@/components/common/size-card';
 
 const DeleteSchematicButton = dynamic(() => import('@/components/schematic/delete-schematic.button'));
 
@@ -69,9 +79,7 @@ export default function UploadSchematicDetailCard({
 					<DetailHeader>
 						<DetailTitle>{name}</DetailTitle>
 						<IdUserCard id={userId} />
-						<span>
-							<Tran text="size" /> {width}x{height}
-						</span>
+						<SizeCard size={{ width, height }} />
 						<DetailDescription>{description}</DetailDescription>
 						<ItemRequirementCard requirements={requirements} />
 						<TagSelector type="schematic" value={selectedTags} onChange={setSelectedTags} />


### PR DESCRIPTION
…rd component

The size display logic was duplicated across multiple components. To improve maintainability and reduce redundancy, the logic has been extracted into a new reusable SizeCard component. This change simplifies the codebase and ensures consistency in how sizes are displayed.