### PR TITLE
fix(constant): correct flag for VI locale

### DIFF
--- a/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
@@ -128,7 +128,7 @@ export default async function Page({ params }: Props) {
 							</div>
 						</div>
 					</div>
-					<div className="flex flex-wrap gap-2 justify-between">
+					<div className="flex gap-2 justify-between flex-col md:flex-row">
 						<div className="flex h-full flex-wrap items-start justify-start gap-1 p-4 shadow-lg flex-1 bg-card rounded-md">
 							<div className="flex h-full flex-col items-start justify-start gap-1">
 								<h3 className="text-xl">
@@ -158,7 +158,7 @@ export default async function Page({ params }: Props) {
 							)}
 						</div>
 						<ProtectedElement session={session} filter={showPlayer}>
-							<div className="flex min-w-[300px] flex-col gap-1 bg-card rounded-md">
+							<div className="flex min-w-[300px] flex-col gap-1 bg-card rounded-md w-full md:w-fit">
 								<div className="flex flex-col gap-2">
 									<h3 className="p-4 text-xl">
 										<Tran text="server.players" /> {players}

--- a/constant/constant.ts
+++ b/constant/constant.ts
@@ -501,7 +501,7 @@ const localeToFlag: Record<string, string> = {
 	VC: '🇻🇨',
 	VE: '🇻🇪',
 	VG: '🇻🇬',
-	VI: '🇻🇮',
+	VI: '🇻🇳',
 	VN: '🇻🇳',
 	VU: '🇻🇺',
 	WF: '🇼🇫',


### PR DESCRIPTION
The flag for the VI locale was incorrectly set to '🇻🇮' instead of '🇻🇳'. This commit fixes the flag to ensure it matches the correct country code.