### PR TITLE
style: reduce padding in card components for consistency

### DIFF
--- a/app/[locale]/(main)/admin/setting/image/page.tsx
+++ b/app/[locale]/(main)/admin/setting/image/page.tsx
@@ -76,7 +76,7 @@ export default function Page() {
 
 function DirCard({ data, setPath }: { data: ImageMetadata; setPath: (path: string) => void }) {
 	return (
-		<div className="p-2 border border-md rounded-md flex gap-1 items-center cursor-pointer">
+		<div className="px-2 py-1 border border-md rounded-md flex gap-1 items-center cursor-pointer">
 			<div className="flex items-center gap-1 w-full justify-start" onClick={() => setPath(data.path)}>
 				<FolderIcon />
 				{data.name}
@@ -91,7 +91,7 @@ function DirCard({ data, setPath }: { data: ImageMetadata; setPath: (path: strin
 
 function FileCard({ data }: { data: ImageMetadata }) {
 	return (
-		<div className="p-2 border-transparent bg-card border-md rounded-md flex gap-1 items-center cursor-pointer">
+		<div className="px-2 py-1 border-transparent bg-card border-md rounded-md flex gap-1 items-center cursor-pointer">
 			<div className="flex items-center gap-1">
 				<FileIcon />
 				{data.name}
@@ -107,7 +107,7 @@ function FileCard({ data }: { data: ImageMetadata }) {
 function ImageCard({ data }: { data: ImageMetadata }) {
 	return (
 		<Dialog>
-			<div className="p-2 border-transparent bg-card border-md rounded-md flex gap-1 items-center cursor-pointer">
+			<div className="px-2 py-1 border-transparent bg-card border-md rounded-md flex gap-1 items-center cursor-pointer">
 				<DialogTrigger asChild>
 					<div className="flex items-center justify-start gap-1 w-full">
 						<motion.img


### PR DESCRIPTION
The padding in card components (`DirCard`, `FileCard`, and `ImageCard`) was reduced from `p-2` to `p-1` to maintain visual consistency across the application and improve alignment with the design system.