### PR TITLE
fix(server): update ban command syntax to include 'add' keyword

### DIFF
--- a/components/server/ban.button.tsx
+++ b/components/server/ban.button.tsx
@@ -37,15 +37,15 @@ export function BanButton({ id, ip, uuid, username }: BanButtonProps) {
 
 	function handleBan() {
 		if (ip) {
-			sendMessage(`ban ip ${ip}`);
+			sendMessage(`ban add ip ${ip}`);
 		}
 
 		if (uuid) {
-			sendMessage(`ban id ${uuid}`);
+			sendMessage(`ban add id ${uuid}`);
 		}
 
 		if (username) {
-			sendMessage(`ban name ${username}`);
+			sendMessage(`ban add name ${username}`);
 		}
 
 		setTimeout(() => {


### PR DESCRIPTION
The ban command syntax was updated to include the 'add' keyword to align with the server's expected command for