### PR TITLE
feat(hooks): add paginationSize from session to search query

### DIFF
--- a/app/[locale]/(main)/translation/compare.table.tsx
+++ b/app/[locale]/(main)/translation/compare.table.tsx
@@ -1,9 +1,13 @@
 import dynamic from 'next/dynamic';
 import { Fragment, useState } from 'react';
 
+
+
 import HighLightTranslation from '@/app/[locale]/(main)/translation/highlight-translation';
 import { TranslationCardSkeleton } from '@/app/[locale]/(main)/translation/translation-card.skeleton';
 import TranslationStatus from '@/app/[locale]/(main)/translation/translation-status';
+
+
 
 import CopyButton from '@/components/button/copy.button';
 import GridPaginationList from '@/components/common/grid-pagination-list';
@@ -14,18 +18,19 @@ import { toast } from '@/components/ui/sonner';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Textarea } from '@/components/ui/textarea';
 
+
+
 import useClientApi from '@/hooks/use-client';
 import { Locale } from '@/i18n/config';
-import {
-	CreateTranslationRequest,
-	createTranslation,
-	getTranslationCompare,
-	getTranslationCompareCount,
-} from '@/query/translation';
+import { CreateTranslationRequest, createTranslation, getTranslationCompare, getTranslationCompareCount } from '@/query/translation';
 import { TranslationCompare } from '@/types/response/Translation';
 import { TranslationPaginationQuery } from '@/types/schema/search-query';
 
+
+
 import { useMutation } from '@tanstack/react-query';
+import { clearTranslationCache } from '@/lib/utils';
+
 
 const DeleteTranslationDialog = dynamic(() => import('@/app/[locale]/(main)/translation/delete-translation.dialog'));
 
@@ -93,6 +98,7 @@ function CompareCard({ translation, language, target }: CompareCardProps) {
 	const { mutate, status } = useMutation({
 		mutationFn: (payload: CreateTranslationRequest) => createTranslation(axios, payload),
 		onError: (error) => toast.error(<Tran text="upload.fail" />, { description: error?.message }),
+		onSuccess: () => clearTranslationCache(),
 	});
 
 	const create = () => {

--- a/app/[locale]/(main)/translation/diff-table.tsx
+++ b/app/[locale]/(main)/translation/diff-table.tsx
@@ -19,6 +19,7 @@ import { TranslationDiff } from '@/types/response/Translation';
 import { TranslationPaginationQuery } from '@/types/schema/search-query';
 
 import { useMutation } from '@tanstack/react-query';
+import { clearTranslationCache } from '@/lib/utils';
 
 type DiffTableProps = {
 	language: Locale;
@@ -53,7 +54,7 @@ export default function DiffTable({ language, target, tKey: key }: DiffTableProp
 						}}
 						asChild
 					>
-						{page =>  page.map((data) => <DiffCard key={data.id} translation={data} language={target} />)}
+						{(page) => page.map((data) => <DiffCard key={data.id} translation={data} language={target} />)}
 					</GridPaginationList>
 				</TableBody>
 			</Table>
@@ -81,6 +82,7 @@ function DiffCard({ translation, language }: DiffCardProps) {
 	const { mutate, status } = useMutation({
 		mutationFn: (payload: CreateTranslationRequest) => createTranslation(axios, payload),
 		onError: (error) => toast.error(<Tran text="upload.fail" />, { description: error?.message }),
+		onSuccess: () => clearTranslationCache(),
 	});
 
 	const create = () => {

--- a/app/[locale]/(main)/translation/page.client.tsx
+++ b/app/[locale]/(main)/translation/page.client.tsx
@@ -20,6 +20,7 @@ const CompareTable = dynamic(() => import('@/app/[locale]/(main)/translation/com
 const AddNewKeyDialog = dynamic(() => import('@/app/[locale]/(main)/translation/add-key.dialog'));
 
 const translateModes = ['search', 'diff', 'compare'] as const;
+
 type TranslateMode = (typeof translateModes)[number];
 
 const defaultState: {
@@ -33,7 +34,7 @@ const defaultState: {
 	language: 'en',
 	mode: 'search',
 	key: '',
-	isTranslated: null,
+	isTranslated: false,
 };
 
 function format(key: null | boolean) {

--- a/app/[locale]/(main)/translation/search.table.tsx
+++ b/app/[locale]/(main)/translation/search.table.tsx
@@ -16,6 +16,7 @@ import { Textarea } from '@/components/ui/textarea';
 
 import useClientApi from '@/hooks/use-client';
 import { Locale } from '@/i18n/config';
+import { clearTranslationCache } from '@/lib/utils';
 import {
 	CreateTranslationRequest,
 	createTranslation,
@@ -58,7 +59,7 @@ export default function SearchTable({ language, tKey: key, isTranslated }: Searc
 						}}
 						asChild
 					>
-						{page =>  page.map((data) => <SearchCard key={data.id} translation={data} language={language} />)}
+						{(page) => page.map((data) => <SearchCard key={data.id} translation={data} language={language} />)}
 					</GridPaginationList>
 				</TableBody>
 			</Table>
@@ -86,6 +87,7 @@ function SearchCard({ translation }: SearchCardProps) {
 	const { mutate, status } = useMutation({
 		mutationFn: (payload: CreateTranslationRequest) => createTranslation(axios, payload),
 		onError: (error) => toast.error(<Tran text="upload.fail" />, { description: error?.message }),
+		onSuccess: () => clearTranslationCache(),
 	});
 
 	const create = () => {

--- a/hooks/use-search-query.ts
+++ b/hooks/use-search-query.ts
@@ -2,10 +2,14 @@ import { useSearchParams } from 'next/navigation';
 import { useMemo } from 'react';
 import { z } from 'zod';
 
+import { useSession } from '@/context/session.context';
 import { groupParamsByKey } from '@/lib/utils';
 import { QuerySchema } from '@/types/schema/search-query';
 
 export default function useSearchQuery<T extends QuerySchema>(schema: T, additional?: Record<string, any>): z.infer<T> {
+	const {
+		config: { paginationSize },
+	} = useSession();
 	const query = useSearchParams();
 	const data = groupParamsByKey(query);
 
@@ -13,9 +17,9 @@ export default function useSearchQuery<T extends QuerySchema>(schema: T, additio
 		const result = schema.parse(data);
 
 		if (additional) {
-			return { ...result, ...additional };
+			return { ...result, ...additional, size: paginationSize };
 		}
 
 		return result;
-	}, [additional, data, schema]);
+	}, [schema, additional, data, paginationSize]);
 }


### PR DESCRIPTION
Include the paginationSize from the session context in the search query result to ensure consistent pagination behavior across the application. This change modifies the useSearchQuery hook to dynamically adjust the query size based on the user's session configuration.