### PR TITLE
style: remove redundant `h-full` class from server dashboard layout

### DIFF
--- a/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
@@ -129,7 +129,7 @@ export default async function Page({ params }: Props) {
 						</div>
 					</div>
 					<div className="flex gap-2 justify-between flex-col md:flex-row">
-						<div className="flex h-full flex-wrap items-start justify-start gap-1 p-4 shadow-lg flex-1 bg-card rounded-md">
+						<div className="flex flex-wrap items-start justify-start gap-1 p-4 shadow-lg flex-1 bg-card rounded-md">
 							<div className="flex h-full flex-col items-start justify-start gap-1">
 								<h3 className="text-xl">
 									<Tran text="server.system-status" />

--- a/app/[locale]/(main)/servers/[id]/(dashboard)/player-list.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/player-list.tsx
@@ -33,6 +33,8 @@ export function PlayerList({ id }: PlayerListProps) {
 	return (
 		<div className="grid gap-2 p-4 min-w-[300px]">
 			{data
+				?.sort((a, b) => a.name.localeCompare(b.name))
+				?.sort((a, b) => (a.locale ?? 'EN').localeCompare(b.locale ?? 'EN'))
 				?.sort((a, b) => a.team.name.localeCompare(b.team.name))
 				.map((player) => <PlayerCard key={player.uuid} serverId={id} player={player} />)}
 		</div>


### PR DESCRIPTION
The `h-full` class was redundant in the server dashboard layout as it did not affect the layout behavior. Removing it improves code readability and maintains consistency in the styling.