### PR TITLE
fix(dashboard): ensure PlayerList only renders when players exist

### DIFF
--- a/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
@@ -158,7 +158,7 @@ export default async function Page({ params }: Props) {
 							)}
 						</div>
 						<ProtectedElement session={session} filter={showPlayer}>
-							{status === 'HOST' && players && (
+							{status === 'HOST' && players > 0 && (
 								<div className="flex min-w-[300px] flex-col gap-1 bg-card rounded-md w-full md:w-fit">
 									<PlayerList id={id} />
 								</div>


### PR DESCRIPTION
The condition for rendering the PlayerList component was updated to check if `players > 0` instead of just checking if `players` is truthy. This prevents the component from rendering when there are no players, improving the UI logic.