### PR TITLE
style: remove redundant height property from grid containers

### DIFF
--- a/app/[locale]/(main)/servers/page.tsx
+++ b/app/[locale]/(main)/servers/page.tsx
@@ -75,7 +75,7 @@ export default async function Page({ searchParams }: Props) {
 				</ServerTabsContent>
 				<ServerTabsContent className="overflow-hidden" value="my-server">
 					<ClientProtectedElement filter alt={<LoginToCreateServer />}>
-						<ScrollContainer className="grid h-full w-full grid-cols-[repeat(auto-fill,minmax(min(350px,100%),1fr))] gap-2">
+						<ScrollContainer className="grid w-full grid-cols-[repeat(auto-fill,minmax(min(350px,100%),1fr))] gap-2">
 							<Suspense fallback={<ServersSkeleton />}>
 								<MeServer />
 							</Suspense>

--- a/app/[locale]/(main)/servers/server-list.tsx
+++ b/app/[locale]/(main)/servers/server-list.tsx
@@ -20,13 +20,13 @@ export default function ServerList() {
 
 	return (
 		<div className="flex h-full w-full gap-2 flex-col">
-			<SearchBar className="max-w-xl bg-card">
+			<SearchBar className="bg-card">
 				<SearchIcon />
 				<SearchInput value={name} onChange={setName} />
 			</SearchBar>
 			<ScrollContainer>
 				<InfinitePage
-					className="grid h-full w-full grid-cols-[repeat(auto-fill,minmax(min(350px,100%),1fr))] gap-2"
+					className="grid w-full grid-cols-[repeat(auto-fill,minmax(min(350px,100%),1fr))] gap-2"
 					queryKey={['server', debounced]}
 					skeleton={{ item: <ServerCardSkeleton />, amount: 20 }}
 					paramSchema={PaginationQuerySchema}


### PR DESCRIPTION
The height property was unnecessarily set to "h-full" in grid containers, which was redundant since the grid layout already handles the height appropriately. This change improves code readability and maintains consistent styling.