### PR TITLE
style(search): add max height to scroll container for better UX

### DIFF
--- a/components/search/name-tag-search.tsx
+++ b/components/search/name-tag-search.tsx
@@ -308,7 +308,7 @@ function AuthorFilter({
 					{isLoading ? (
 						<LoadingSpinner />
 					) : (
-						<ScrollContainer className="space-y-2">
+						<ScrollContainer className="space-y-2 max-h-[50dvh]">
 							{data?.map((user) => (
 								<div
 									className={cn('cursor-pointer p-2 rounded-md bg-secondary', {


### PR DESCRIPTION
The `max-h-[50dvh]` class was added to the `ScrollContainer` to limit its height, improving the user experience by preventing the container from becoming too large and overwhelming the interface.