### PR TITLE
fix(bulk-action): correct size of SquareIcon to match SquareCheckedIcon

### DIFF
--- a/components/common/bulk-action.tsx
+++ b/components/common/bulk-action.tsx
@@ -167,7 +167,7 @@ export function BulkActionSelector({ className, value, children }: BulkActionSel
 					{children}
 				</div>
 				<div className={cn('absolute right-1 top-1 size-6 p-0', className, { 'pointer-events-none': show })}>
-					{isSelected ? <SquareCheckedIcon className="size-6" /> : <SquareIcon className="size-10" />}
+					{isSelected ? <SquareCheckedIcon className="size-6" /> : <SquareIcon className="size-6" />}
 				</div>
 			</div>
 		);


### PR DESCRIPTION
The size of SquareIcon was incorrectly set to 'size-10', which caused inconsistency with SquareCheckedIcon. This fix ensures both icons have the same size ('size-6') for a uniform appearance.