### PR TITLE
feat(translation): add support for viewing all translations in a table

### DIFF
--- a/app/[locale]/(main)/translation/all.table.tsx
+++ b/app/[locale]/(main)/translation/all.table.tsx
@@ -1,0 +1,154 @@
+import { LanguagesIcon } from 'lucide-react';
+import dynamic from 'next/dynamic';
+import { Fragment, Suspense, useState } from 'react';
+
+import HighLightTranslation from '@/app/[locale]/(main)/translation/highlight-translation';
+import { TranslationCardSkeleton } from '@/app/[locale]/(main)/translation/translation-card.skeleton';
+import TranslationStatus from '@/app/[locale]/(main)/translation/translation-status';
+
+import GridPaginationList from '@/components/common/grid-pagination-list';
+import { EditIcon } from '@/components/common/icons';
+import PaginationNavigator from '@/components/common/pagination-navigator';
+import ScrollContainer from '@/components/common/scroll-container';
+import Tran from '@/components/common/tran';
+import { EllipsisButton } from '@/components/ui/ellipsis-button';
+import { toast } from '@/components/ui/sonner';
+import { Textarea } from '@/components/ui/textarea';
+
+import useClientApi from '@/hooks/use-client';
+import { Locale, locales } from '@/i18n/config';
+import { clearTranslationCache } from '@/lib/utils';
+import { CreateTranslationRequest, createTranslation, getTranslationAll, getTranslationAllCount } from '@/query/translation';
+import { TranslationAll, TranslationAllValue } from '@/types/response/Translation';
+import { AllTranslationPaginationQuery } from '@/types/schema/search-query';
+
+import { useMutation } from '@tanstack/react-query';
+
+const DeleteTranslationDialog = dynamic(() => import('@/app/[locale]/(main)/translation/delete-translation.dialog'));
+
+type AllTableProps = {
+	tKey?: string;
+};
+
+export default function AllTable({ tKey: key }: AllTableProps) {
+	return (
+		<Fragment>
+			<ScrollContainer className="gap-2 flex flex-col">
+				<GridPaginationList
+					paramSchema={AllTranslationPaginationQuery}
+					params={{ key }}
+					queryKey={['translations', 'all', key]}
+					queryFn={getTranslationAll}
+					noResult={<Fragment></Fragment>}
+					skeleton={{
+						amount: 20,
+						item: (index) => <TranslationCardSkeleton key={index} />,
+					}}
+					asChild
+				>
+					{(page) => page.map((data) => <AllCard key={data.keyGroup + data.key} translation={data} />)}
+				</GridPaginationList>
+			</ScrollContainer>
+			<div className="mt-auto flex justify-end space-x-2">
+				<PaginationNavigator
+					numberOfItems={(axios) => getTranslationAllCount(axios, { key: key })}
+					queryKey={['translations', 'all', 'total', key]}
+				/>
+			</div>
+		</Fragment>
+	);
+}
+
+type AllCardProps = {
+	translation: TranslationAll;
+};
+
+function AllCard({ translation }: AllCardProps) {
+	const { key, value, keyGroup } = translation;
+
+	return (
+		<div className="flex flex-col gap-1 bg-card p-2 rounded-md border">
+			<div className="uppercase">
+				{keyGroup}.{key}
+			</div>
+			{locales.map((locale) => (
+				<ValueCard
+					key={locale}
+					tKey={key}
+					keyGroup={keyGroup}
+					locale={locale}
+					value={
+						value[locale] ?? {
+							id: '',
+							value: key,
+							isTranslated: false,
+						}
+					}
+				/>
+			))}
+		</div>
+	);
+}
+
+type ValueCardProps = {
+	tKey: string;
+	keyGroup: string;
+	locale: Locale;
+	value: TranslationAllValue;
+};
+
+function ValueCard({ tKey: key, keyGroup, value, locale }: ValueCardProps) {
+	const [currentValue, setCurrentValue] = useState(value);
+	const [isEdit, setEdit] = useState(false);
+	const axios = useClientApi();
+
+	const { mutate, status } = useMutation({
+		mutationFn: (payload: CreateTranslationRequest) => createTranslation(axios, payload),
+		onError: (error) => toast.error(<Tran text="upload.fail" />, { description: error?.message }),
+		onSuccess: () => clearTranslationCache(),
+	});
+
+	const create = () => {
+		mutate({
+			key,
+			keyGroup,
+			language: locale,
+			value: currentValue?.value ?? key,
+		});
+	};
+
+	return (
+		<div className="w-full flex justify-between text-xs p-2 bg-secondary rounded-md">
+			<div className="flex gap-1 items-start w-full" onClick={() => setEdit(true)}>
+				{currentValue.isTranslated ? <EditIcon className="size-4" /> : <LanguagesIcon />}
+				<Tran className="text-nowrap text-foreground uppercase" text={locale} />
+				{isEdit ? ( //
+					<Textarea
+						className="border-transparent p-0 outline-none ring-0 focus-visible:outline-none focus-visible:ring-0 w-full h-fit min-h-fit"
+						autoFocus
+						defaultValue={currentValue?.value ?? key}
+						onChange={(event) => setCurrentValue((prev) => ({ ...prev, value: event.target.value }))}
+						onBlur={() => {
+							setEdit(false);
+							create();
+						}}
+					/>
+				) : (
+					<span className="text-muted-foreground">
+						<HighLightTranslation text={currentValue?.value ?? key} />
+					</span>
+				)}
+			</div>
+			<div className="flex gap-2 items-center">
+				<TranslationStatus status={status} />
+				{currentValue.id && (
+					<EllipsisButton>
+						<Suspense>
+							<DeleteTranslationDialog value={{ key, id: currentValue.id }} />
+						</Suspense>
+					</EllipsisButton>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/app/[locale]/(main)/translation/page.client.tsx
+++ b/app/[locale]/(main)/translation/page.client.tsx
@@ -3,6 +3,7 @@
 import dynamic from 'next/dynamic';
 import { Fragment, useCallback, useState } from 'react';
 
+import AllTable from '@/app/[locale]/(main)/translation/all.table';
 import SearchTable from '@/app/[locale]/(main)/translation/search.table';
 
 import ComboBox from '@/components/common/combo-box';
@@ -19,7 +20,7 @@ const DiffTable = dynamic(() => import('@/app/[locale]/(main)/translation/diff-t
 const CompareTable = dynamic(() => import('@/app/[locale]/(main)/translation/compare.table'));
 const AddNewKeyDialog = dynamic(() => import('@/app/[locale]/(main)/translation/add-key.dialog'));
 
-const translateModes = ['search', 'diff', 'compare'] as const;
+const translateModes = ['search', 'diff', 'compare', 'all'] as const;
 
 type TranslateMode = (typeof translateModes)[number];
 
@@ -97,29 +98,31 @@ export default function TranslationPage() {
 							onChange={(language) => setState({ language })}
 						/>
 					) : (
-						<>
-							<ComboBox<Locale>
-								className="h-10"
-								searchBar={false}
-								value={{ label: t(language ?? 'en'), value: language ?? ('en' as Locale) }}
-								values={locales.map((locale) => ({
-									label: t(locale),
-									value: locale,
-								}))}
-								onChange={(language) => setState({ language: language ?? 'en' })}
-							/>
-							{'=>'}
-							<ComboBox<Locale>
-								className="h-10"
-								searchBar={false}
-								value={{ label: t(target), value: target as Locale }}
-								values={locales.map((locale) => ({
-									label: t(locale),
-									value: locale,
-								}))}
-								onChange={(target) => setState({ target: target ?? 'en' })}
-							/>
-						</>
+						(mode === 'compare' || mode === 'diff') && (
+							<>
+								<ComboBox<Locale>
+									className="h-10"
+									searchBar={false}
+									value={{ label: t(language ?? 'en'), value: language ?? ('en' as Locale) }}
+									values={locales.map((locale) => ({
+										label: t(locale),
+										value: locale,
+									}))}
+									onChange={(language) => setState({ language: language ?? 'en' })}
+								/>
+								{'=>'}
+								<ComboBox<Locale>
+									className="h-10"
+									searchBar={false}
+									value={{ label: t(target), value: target as Locale }}
+									values={locales.map((locale) => ({
+										label: t(locale),
+										value: locale,
+									}))}
+									onChange={(target) => setState({ target: target ?? 'en' })}
+								/>
+							</>
+						)
 					)}
 					<SearchBar>
 						<SearchInput placeholder={t('search-by-key')} value={key} onChange={(value) => setState({ key: value })} />
@@ -131,8 +134,10 @@ export default function TranslationPage() {
 					<CompareTable language={language as Locale} target={target as Locale} tKey={key} />
 				) : mode === 'search' ? (
 					<SearchTable language={language as Locale} tKey={key} isTranslated={isTranslated} />
-				) : (
+				) : mode === 'diff' ? (
 					<DiffTable language={language as Locale} target={target as Locale} tKey={key} />
+				) : (
+					<AllTable tKey={key} />
 				)}
 			</div>
 			<div className="flex h-full w-full items-center justify-center landscape:hidden">

--- a/query/translation.ts
+++ b/query/translation.ts
@@ -2,7 +2,7 @@ import { AxiosInstance } from 'axios';
 import { z } from 'zod';
 
 import { Locale } from '@/i18n/config';
-import { Translation, TranslationCompare, TranslationDiff } from '@/types/response/Translation';
+import { Translation, TranslationAll, TranslationCompare, TranslationDiff } from '@/types/response/Translation';
 import { PaginationQuery } from '@/types/schema/search-query';
 
 export async function getTranslationDiff(axios: AxiosInstance, params: PaginationQuery & { language: Locale; target: Locale; key?: string }): Promise<TranslationDiff[]> {
@@ -13,6 +13,19 @@ export async function getTranslationDiff(axios: AxiosInstance, params: Paginatio
 
 export async function getTranslationDiffCount(axios: AxiosInstance, params: { language: Locale; target: Locale; key?: string }) {
 	const result = await axios.get('/translations/diff/count', {
+		params,
+	});
+
+	return result.data;
+}
+export async function getTranslationAll(axios: AxiosInstance, params: PaginationQuery & { key?: string }): Promise<TranslationAll[]> {
+	const result = await axios.get('/translations/all', { params });
+
+	return result.data;
+}
+
+export async function getTranslationAllCount(axios: AxiosInstance, params: { key?: string }) {
+	const result = await axios.get('/translations/all/count', {
 		params,
 	});
 

--- a/types/response/Translation.ts
+++ b/types/response/Translation.ts
@@ -1,24 +1,36 @@
 import { Locale } from '@/i18n/config';
 
 export type TranslationDiff = {
-  id: string;
-  key: string;
-  value: string;
-  keyGroup: string;
+	id: string;
+	key: string;
+	value: string;
+	keyGroup: string;
+};
+
+export type TranslationAllValue = {
+	id: string;
+	value: string;
+	isTranslated: boolean;
+};
+
+export type TranslationAll = {
+	key: string;
+	value: Partial<Record<Locale, TranslationAllValue>>;
+	keyGroup: string;
 };
 
 export type TranslationCompare = {
-  id: string;
-  key: string;
-  value: Record<Locale, string>;
-  keyGroup: string;
+	id: string;
+	key: string;
+	value: Record<Locale, string>;
+	keyGroup: string;
 };
 
 export type Translation = {
-  id: string;
-  key: string;
-  value: string;
-  keyGroup: string;
-  language: string;
-  isTranslated?: boolean;
+	id: string;
+	key: string;
+	value: string;
+	keyGroup: string;
+	language: string;
+	isTranslated?: boolean;
 };

--- a/types/schema/search-query.ts
+++ b/types/schema/search-query.ts
@@ -75,6 +75,11 @@ export const TranslationPaginationQuery = z.object({
 	isTranslated: isTranslatedSchema,
 });
 
+export const AllTranslationPaginationQuery = z.object({
+	...PaginationParam,
+	key: languageKeySchema,
+});
+
 export type PaginationQuery = {
 	page: number;
 	size: number;


### PR DESCRIPTION
This commit introduces a new feature that allows users to view all translations in a table format. The changes include:
- Adding a new `AllTable` component to display translations
- Extending the schema and response types to support the new feature
- Updating the translation page to include the new table mode