### PR TITLE
feat(metadata): enhance openGraph descriptions with stats

### DIFF
--- a/app/[locale]/(main)/maps/[id]/page.tsx
+++ b/app/[locale]/(main)/maps/[id]/page.tsx
@@ -25,14 +25,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 		return { title: 'Error' };
 	}
 
-	const { name, description } = map;
+	const { name, description, downloadCount, likes, dislikes } = map;
 
 	return {
 		title: formatTitle(name),
 		description: [name, description].join('|'),
 		openGraph: {
 			title: name,
-			description: description,
+			description: `⬇️${downloadCount} 👍${likes} 👎${dislikes}\n${description}`,
 			images: `${env.url.image}/maps/${id}${env.imageFormat}`,
 		},
 		alternates: generateAlternate(`/maps/${id}`),

--- a/app/[locale]/(main)/schematics/[id]/page.tsx
+++ b/app/[locale]/(main)/schematics/[id]/page.tsx
@@ -25,14 +25,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 		return { title: 'Error' };
 	}
 
-	const { name, description } = schematic;
+	const { name, description, downloadCount, likes, dislikes } = schematic;
 
 	return {
 		title: formatTitle(name),
 		description: [name, description].join('|'),
 		openGraph: {
 			title: name,
-			description: description,
+			description: `⬇️${downloadCount} 👍${likes} 👎${dislikes}\n${description}`,
 			images: `${env.url.image}/schematics/${id}${env.imageFormat}`,
 		},
 		alternates: generateAlternate(`/schematics/${id}`),

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -58,6 +58,7 @@ export const metadata: Metadata = {
 		images: 'https://mindustrygame.github.io/1.d25af17a.webp',
 		title: 'Mindustry',
 		description: 'MindustryTool',
+		siteName: 'MindustryTool',
 	},
 	alternates: generateAlternate('/'),
 	robots: {


### PR DESCRIPTION
Add siteName to metadata in layout and include downloadCount, likes, and dislikes in openGraph descriptions for maps and schematics pages to provide more detailed information