### PR TITLE
feat(metadata): add authors and tags to openGraph metadata

### DIFF
--- a/app/[locale]/(main)/maps/[id]/page.tsx
+++ b/app/[locale]/(main)/maps/[id]/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 		return { title: 'Error' };
 	}
 
-	const { name, description, downloadCount, likes, dislikes, userId, tags } = map;
+	const { name, description, downloadCount, likes, dislikes, userId, tags, createdAt } = map;
 
 	return {
 		title: formatTitle(name),
@@ -37,6 +37,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 			images: `${env.url.image}/maps/${id}${env.imageFormat}`,
 			authors: [`${env.url.image}/users/${userId}`],
 			tags: tags.map((tag) => tag.name),
+			publishedTime: new Date(createdAt).toISOString(),
 		},
 		alternates: generateAlternate(`/maps/${id}`),
 	};

--- a/app/[locale]/(main)/maps/[id]/page.tsx
+++ b/app/[locale]/(main)/maps/[id]/page.tsx
@@ -25,15 +25,18 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 		return { title: 'Error' };
 	}
 
-	const { name, description, downloadCount, likes, dislikes } = map;
+	const { name, description, downloadCount, likes, dislikes, userId, tags } = map;
 
 	return {
 		title: formatTitle(name),
 		description: [name, description].join('|'),
 		openGraph: {
+			type: 'article',
 			title: name,
 			description: `⬇️${downloadCount} 👍${likes} 👎${dislikes}\n${description}`,
 			images: `${env.url.image}/maps/${id}${env.imageFormat}`,
+			authors: [`${env.url.image}/users/${userId}`],
+			tags: tags.map((tag) => tag.name),
 		},
 		alternates: generateAlternate(`/maps/${id}`),
 	};

--- a/app/[locale]/(main)/schematics/[id]/page.tsx
+++ b/app/[locale]/(main)/schematics/[id]/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 		return { title: 'Error' };
 	}
 
-	const { name, description, downloadCount, likes, dislikes, userId, tags } = schematic;
+	const { name, description, downloadCount, likes, dislikes, userId, tags, createdAt } = schematic;
 
 	return {
 		title: formatTitle(name),
@@ -36,6 +36,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 			images: `${env.url.image}/schematics/${id}${env.imageFormat}`,
 			authors: [`${env.url.image}/users/${userId}`],
 			tags: tags.map((tag) => tag.name),
+			publishedTime: new Date(createdAt).toISOString(),
 		},
 		alternates: generateAlternate(`/schematics/${id}`),
 	};

--- a/app/[locale]/(main)/schematics/[id]/page.tsx
+++ b/app/[locale]/(main)/schematics/[id]/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 		return { title: 'Error' };
 	}
 
-	const { name, description, downloadCount, likes, dislikes } = schematic;
+	const { name, description, downloadCount, likes, dislikes, userId, tags } = schematic;
 
 	return {
 		title: formatTitle(name),
@@ -34,6 +34,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 			title: name,
 			description: `⬇️${downloadCount} 👍${likes} 👎${dislikes}\n${description}`,
 			images: `${env.url.image}/schematics/${id}${env.imageFormat}`,
+			authors: [`${env.url.image}/users/${userId}`],
+			tags: tags.map((tag) => tag.name),
 		},
 		alternates: generateAlternate(`/schematics/${id}`),
 	};


### PR DESCRIPTION
Enhance the openGraph metadata for maps and schematics by including authors and tags. This improves the richness of the metadata, providing more context and discoverability for shared links.