### PR TITLE
feat(i18n): add translation support for tags in metadata

### DIFF
--- a/app/[locale]/(main)/maps/[id]/page.tsx
+++ b/app/[locale]/(main)/maps/[id]/page.tsx
@@ -7,6 +7,7 @@ import MapDetailCard from '@/components/map/map-detail-card';
 import { serverApi } from '@/action/common';
 import env from '@/constant/env';
 import { Locale } from '@/i18n/config';
+import { getTranslation } from '@/i18n/server';
 import { isError } from '@/lib/error';
 import { formatTitle, generateAlternate } from '@/lib/utils';
 import { getMap } from '@/query/map';
@@ -19,9 +20,9 @@ type Props = {
 const getCachedMap = cache((id: string) => serverApi((axios) => getMap(axios, { id })));
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-	const { id } = await params;
+	const { id, locale } = await params;
+	const { t } = await getTranslation(locale, ['tags']);
 	const map = await getCachedMap(id);
-
 	if (isError(map)) {
 		return { title: 'Error' };
 	}
@@ -40,7 +41,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 		openGraph: {
 			type: 'article',
 			title: name,
-			description: `Author: ${user.name} ⬇️\n\n${downloadCount} 👍${likes} 👎${dislikes}\n\nTags: ${tags.map((tag) => tag.name)} \n\n \n\n${description}`,
+			description: `Author: ${user.name} ⬇️\n\n${downloadCount} 👍${likes} 👎${dislikes}\n\nTags: ${tags.map((tag) => t(tag.name))} \n\n \n\n${description}`,
 			images: `${env.url.image}/maps/${id}${env.imageFormat}`,
 			authors: [`${env.url.image}/users/${userId}`],
 			tags: tags.map((tag) => tag.name),

--- a/app/[locale]/(main)/schematics/[id]/page.tsx
+++ b/app/[locale]/(main)/schematics/[id]/page.tsx
@@ -7,6 +7,7 @@ import SchematicDetailCard from '@/components/schematic/schematic-detail-card';
 import { serverApi } from '@/action/common';
 import env from '@/constant/env';
 import { Locale } from '@/i18n/config';
+import { getTranslation } from '@/i18n/server';
 import { isError } from '@/lib/error';
 import { formatTitle, generateAlternate } from '@/lib/utils';
 import { getSchematic } from '@/query/schematic';
@@ -19,7 +20,8 @@ type Props = {
 const getCachedSchematic = cache((id: string) => serverApi((axios) => getSchematic(axios, { id })));
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-	const { id } = await params;
+	const { id, locale } = await params;
+	const { t } = await getTranslation(locale, ['tags']);
 	const schematic = await getCachedSchematic(id);
 
 	if (isError(schematic)) {
@@ -40,7 +42,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 		openGraph: {
 			type: 'article',
 			title: name,
-			description: `Author: ${user.name}\n\n⬇️${downloadCount} 👍${likes} 👎${dislikes} \n\nTags: ${tags.map((tag) => tag.name)} \n\n${description}`,
+			description: `Author: ${user.name}\n\n⬇️${downloadCount} 👍${likes} 👎${dislikes} \n\nTags: ${tags.map((tag) => t(tag.name))} \n\n${description}`,
 			images: `${env.url.image}/schematics/${id}${env.imageFormat}`,
 			authors: [`${env.url.image}/users/${userId}`],
 			tags: tags.map((tag) => tag.name),

--- a/i18n/client.ts
+++ b/i18n/client.ts
@@ -6,7 +6,7 @@ import Backend, { ChainedBackendOptions } from 'i18next-chained-backend';
 import HttpApi, { HttpBackendOptions } from 'i18next-http-backend';
 import LocalStorageBackend from 'i18next-localstorage-backend';
 import { useParams, usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useCookies } from 'react-cookie';
 import { initReactI18next, useTranslation as useTranslationOrg } from 'react-i18next';
 
@@ -66,6 +66,7 @@ export default i18next;
 
 export function useI18n(namespace: string | string[] = 'common', options?: any) {
 	const { locale } = useParams();
+	namespace = Array.isArray(namespace) ? namespace.map((n) => n.toLowerCase()) : namespace.toLowerCase();
 
 	let language = String(locale);
 
@@ -74,7 +75,7 @@ export function useI18n(namespace: string | string[] = 'common', options?: any) 
 	const [cookies, setCookie] = useCookies([cookieName]);
 	const ret = useTranslationOrg(namespace, options);
 
-	const { i18n } = ret;
+	const { i18n, t } = ret;
 	if (runsOnServerSide && language && i18n.resolvedLanguage !== language) {
 		i18n.changeLanguage(language);
 	} else {
@@ -103,7 +104,12 @@ export function useI18n(namespace: string | string[] = 'common', options?: any) 
 			// eslint-disable-next-line react-hooks/exhaustive-deps
 		}, [language, cookies[cookieName]]);
 	}
-	return ret;
+
+	const retT = useCallback((key: string, options?: any) => t(key, options) as string, [t]);
+	return {
+		...ret,
+		t: retT,
+	};
 }
 
 export function useChangeLocale() {

--- a/i18n/server.ts
+++ b/i18n/server.ts
@@ -74,11 +74,13 @@ const initI18next = async (language: Locale, namespace?: string | string[]) => {
 export const getTranslation = cache(
 	async (locale: Locale, namespace: string | string[] = 'common', options: { keyPrefix?: string } = {}) => {
 		const language = locales.includes(locale as any) ? locale : defaultLocale;
+		namespace = Array.isArray(namespace)? namespace.map(n => n.toLowerCase()) : namespace.toLowerCase();
 
 		const i18nextInstance = await initI18next(language, namespace);
+		const t = i18nextInstance.getFixedT(language, namespace, options.keyPrefix)
 
 		return {
-			t: i18nextInstance.getFixedT(language, namespace, options.keyPrefix),
+			t: (key: string, options?: any) => t(key.toLowerCase(), options) as string,
 			i18n: i18nextInstance,
 		};
 	},


### PR DESCRIPTION
This commit introduces translation support for tags in the metadata generation of maps and schematics pages. The `getTranslation` function is now used to translate tag names, improving localization for international users.