### PR TITLE
feat(mod-filter): support multiple mod selection in filter component

### DIFF
--- a/app/[locale]/(main)/admin/setting/mods/update-mod.dialog.tsx
+++ b/app/[locale]/(main)/admin/setting/mods/update-mod.dialog.tsx
@@ -97,7 +97,25 @@ export default function UpdateModDialog({ mod }: Props) {
 									<FormMessage />
 								</FormItem>
 							)}
-						/>{' '}
+						/>
+						<FormField
+							control={form.control}
+							name="position"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>
+										<Tran text="mod.position" />
+									</FormLabel>
+									<FormControl>
+										<Input type="number" {...field} onChange={(e) => field.onChange(e.currentTarget.valueAsNumber)} />
+									</FormControl>
+									<FormDescription>
+										<Tran text="mod.position" />
+									</FormDescription>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
 						<FormField
 							control={form.control}
 							name="icon"

--- a/components/search/mod-filter.tsx
+++ b/components/search/mod-filter.tsx
@@ -8,44 +8,69 @@ import { Mod } from '@/types/response/Mod';
 
 import { useQuery } from '@tanstack/react-query';
 
-type Props = {
-  value?: Mod;
-  onValueSelected: (mod?: Mod) => void;
-};
+type Props =
+	| {
+			multiple?: false;
+			value?: Mod;
+			onValueSelected: (mod?: Mod) => void;
+	  }
+	| {
+			multiple: true;
+			value: Mod[];
+			onValueSelected: (mods: Mod[]) => void;
+	  };
 
-export default function ModFilter({ value, onValueSelected }: Props) {
-  const axios = useClientApi();
+export default function ModFilter({ multiple, value, onValueSelected }: Props) {
+	const axios = useClientApi();
 
-  const { data } = useQuery({
-    queryKey: ['mods'],
-    queryFn: () => getMods(axios),
-  });
+	const { data } = useQuery({
+		queryKey: ['mods'],
+		queryFn: () => getMods(axios),
+	});
 
-  const mods = data ?? [];
-  return (
-    <div className="flex gap-2 hover:overflow-x-auto focus:overflow-x-auto overflow-hidden w-full pb-2 h-12">
-      {mods.map((mod) => (
-        <ModCard key={mod.id} value={value} mod={mod} onValueSelected={(selected) => onValueSelected(selected === value ? undefined : selected)} />
-      ))}
-    </div>
-  );
+	const mods = data ?? [];
+	return (
+		<div className="flex gap-2 hover:overflow-x-auto focus:overflow-x-auto overflow-hidden w-full pb-2 h-12">
+			{mods.map((mod) => (
+				<ModCard
+					key={mod.id}
+					isSelected={multiple ? value?.some((v) => v.id === mod.id) : value?.id === mod.id}
+					mod={mod}
+					onValueSelected={(selected) => (multiple ? onValueSelected([...(value ?? []), selected]) : onValueSelected(selected))}
+				/>
+			))}
+		</div>
+	);
 }
 
 type ModCardProps = {
-  mod: Mod;
-  value?: Mod;
-  onValueSelected: (mod: Mod) => void;
+	mod: Mod;
+	isSelected: boolean;
+	onValueSelected: (mod: Mod) => void;
 };
-function ModCard({ mod, value, onValueSelected }: ModCardProps) {
-  return (
-    <div
-      className={cn('flex gap-1 rounded-full bg-secondary p-1 text-sm text-center items-center cursor-pointer justify-center border min-w-20 shrink-0 hover:bg-brand hover:text-brand-foreground', {
-        'bg-brand text-brand-foreground': value === mod,
-      })}
-      onClick={() => onValueSelected(mod)}
-    >
-      {mod.icon && <Image key={mod.icon} width={48} height={48} className="size-8 object-cover rounded-full" src={mod.icon} loader={({ src }) => src} alt="preview" />}
-      {mod.name}
-    </div>
-  );
+function ModCard({ mod, isSelected, onValueSelected }: ModCardProps) {
+	return (
+		<div
+			className={cn(
+				'flex gap-1 rounded-full bg-secondary p-1 pr-2 text-sm text-center items-center cursor-pointer justify-center border min-w-20 shrink-0 hover:bg-brand hover:text-brand-foreground',
+				{
+					'bg-brand text-brand-foreground': isSelected,
+				},
+			)}
+			onClick={() => onValueSelected(mod)}
+		>
+			{mod.icon && (
+				<Image
+					key={mod.icon}
+					width={48}
+					height={48}
+					className="size-8 object-cover rounded-full"
+					src={mod.icon}
+					loader={({ src }) => src}
+					alt="preview"
+				/>
+			)}
+			{mod.name}
+		</div>
+	);
 }

--- a/components/search/name-tag-search.tsx
+++ b/components/search/name-tag-search.tsx
@@ -52,7 +52,7 @@ type NameTagSearchProps = {
 
 export default function NameTagSearch({ className, type, useSort = true, useTag = true }: NameTagSearchProps) {
 	const [filter, setFilter] = useState('');
-	const [selectedMod, setSelectedMod] = useState<Mod | undefined>(undefined);
+	const [selectedMod, setSelectedMod] = useState<Mod[]>([]);
 
 	const params = useSearchQuery(ItemPaginationQuery);
 
@@ -238,7 +238,7 @@ export default function NameTagSearch({ className, type, useSort = true, useTag 
 							<ScrollContainer className="overscroll-none space-y-2">
 								<AuthorFilter authorId={authorId} handleAuthorChange={handleAuthorChange} />
 								<Separator className="border" orientation="horizontal" />
-								<ModFilter value={selectedMod} onValueSelected={setSelectedMod} />
+								<ModFilter multiple value={selectedMod} onValueSelected={setSelectedMod} />
 								<FilterTags filter={filter} filterBy={filterBy} tags={tags} handleTagGroupChange={handleTagGroupChange} />
 							</ScrollContainer>
 							<Divider />

--- a/components/search/tag-selector.tsx
+++ b/components/search/tag-selector.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import dynamic from 'next/dynamic';
 import React, { useCallback, useState } from 'react';
 
@@ -16,12 +14,12 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardFooter } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
 
+import { PresetType } from '@/constant/constant';
 import useTags from '@/hooks/use-tags';
 import { cn } from '@/lib/utils';
 import { Mod } from '@/types/response/Mod';
 import Tag from '@/types/response/Tag';
 import TagGroup from '@/types/response/TagGroup';
-import { PresetType } from '@/constant/constant';
 
 const FilterTags = dynamic(() => import('@/components/tag/filter-tags'));
 
@@ -34,7 +32,7 @@ type TagSelectorProps = {
 };
 
 export default function TagSelector({ type, value, onChange, disabled = false, hideSelectedTag }: TagSelectorProps) {
-	const [selectedMod, setSelectedMod] = useState<Mod | undefined>(undefined);
+	const [selectedMod, setSelectedMod] = useState<Mod[]>([]);
 	const [filter, setFilter] = useState('');
 
 	const [showFilterDialog, setShowFilterDialog] = useState(false);
@@ -101,7 +99,13 @@ export default function TagSelector({ type, value, onChange, disabled = false, h
 		>
 			<div className="flex flex-col gap-2">
 				<div className="flex gap-2">
-					<Button className="w-fit text-nowrap" variant="primary" title="add-tag" disabled={disabled} onClick={handleShowFilterDialog}>
+					<Button
+						className="w-fit text-nowrap"
+						variant="primary"
+						title="add-tag"
+						disabled={disabled}
+						onClick={handleShowFilterDialog}
+					>
 						<Tran text="add-tag" />
 					</Button>
 					<TagPreset type={type} onPresetChoose={(value) => onChange(() => value)} />
@@ -113,10 +117,15 @@ export default function TagSelector({ type, value, onChange, disabled = false, h
 					<Card className="grid grid-rows-[auto_1fr_auto] h-full w-full gap-2 rounded-none p-4 md:rounded-lg ">
 						<SearchBar className="w-full p-1">
 							<SearchIcon className="p-1" />
-							<SearchInput value={filter} placeholder="filter" onChange={(value) => setFilter(value)} onClear={() => setFilter('')} />
+							<SearchInput
+								value={filter}
+								placeholder="filter"
+								onChange={(value) => setFilter(value)}
+								onClear={() => setFilter('')}
+							/>
 						</SearchBar>
 						<ScrollContainer className="overscroll-none h-full">
-							<ModFilter value={selectedMod} onValueSelected={setSelectedMod} />
+							<ModFilter multiple value={selectedMod} onValueSelected={setSelectedMod} />
 							<Separator className="border" orientation="horizontal" />
 							<CardContent className="flex h-full w-full flex-col p-0 ">
 								<FilterTags filter={filter} filterBy={value} tags={tags} handleTagGroupChange={handleTagGroupChange} />

--- a/hooks/use-tags.ts
+++ b/hooks/use-tags.ts
@@ -4,20 +4,31 @@ import { getTags } from '@/query/tag';
 import { Mod } from '@/types/response/Mod';
 import TagGroup, { AllTagGroup } from '@/types/response/TagGroup';
 
-import { useQuery } from '@tanstack/react-query';
+import { useQueries } from '@tanstack/react-query';
 
-export default function useTags(type: TagType, mod?: Mod) {
-  const axios = useClientApi();
-  const { data } = useQuery({
-    queryKey: ['tags', mod?.id],
-    queryFn: async () => getTags(axios, mod?.id),
-  });
+export default function useTags(type: TagType, mod: Mod[]) {
+	const axios = useClientApi();
 
-  return validateTags(data, type);
+	const queries = useQueries({
+		queries: [
+			{
+				queryKey: ['tags'],
+				queryFn: async () => getTags(axios),
+			},
+			...mod.map((v) => {
+				return {
+					queryKey: ['tags', v.id],
+					queryFn: async () => getTags(axios, v.id),
+				};
+			}),
+		],
+	});
+
+	return queries.flatMap((query) => validateTags(query.data, type));
 }
 
 function validateTags(data: AllTagGroup | undefined, type: TagType): TagGroup[] {
-  const result = data && type in data ? data[type]?.filter((v) => v.values.length > 0) : [];
+	const result = data && type in data ? data[type]?.filter((v) => v.values.length > 0) : [];
 
-  return result ?? [];
+	return result ?? [];
 }

--- a/query/mod.ts
+++ b/query/mod.ts
@@ -28,6 +28,7 @@ export type CreateModRequest = z.infer<typeof CreateModSchema>;
 export const UpdateModSchema = z.object({
   name: z.string().min(1).max(100),
   icon: z.any(),
+  position: z.number().default(0),
 });
 
 export type UpdateModRequest = z.infer<typeof UpdateModSchema>;

--- a/types/response/Mod.ts
+++ b/types/response/Mod.ts
@@ -2,4 +2,5 @@ export type Mod = {
   id: string;
   name: string;
   icon: string;
+  position: number;
 };


### PR DESCRIPTION
This commit introduces the ability to select multiple mods in the mod filter component. The changes include updating the state to handle an array of mods, modifying the `ModFilter` component to support multiple selections, and adjusting related components and hooks to accommodate this new functionality. This enhancement improves the user experience by allowing more flexible filtering options.