### PR TITLE
fix(search): correct mod filter selection logic for multiple values

### DIFF
--- a/components/search/mod-filter.tsx
+++ b/components/search/mod-filter.tsx
@@ -37,7 +37,11 @@ export default function ModFilter({ multiple, value, onValueSelected }: Props) {
 					isSelected={multiple ? value?.some((v) => v.id === mod.id) : value?.id === mod.id}
 					mod={mod}
 					onValueSelected={(selected) =>
-						multiple ? onValueSelected([...value, selected]) : onValueSelected(value?.id === selected.id ? undefined : selected)
+						multiple
+							? value.some((v) => v.id === selected.id)
+								? onValueSelected(value.filter((v) => v.id === selected.id))
+								: onValueSelected([...value, selected])
+							: onValueSelected(value?.id === selected.id ? undefined : selected)
 					}
 				/>
 			))}


### PR DESCRIPTION
The previous implementation did not handle deselection correctly for multiple values. This fix ensures that when a mod is already selected in a multiple selection scenario, it is properly removed from the list instead of being added again.