### PR TITLE
refactor: remove React cache from readDocs and getTranslation

### DIFF
--- a/app/[locale]/(main)/medium-nav.footer.tsx
+++ b/app/[locale]/(main)/medium-nav.footer.tsx
@@ -22,7 +22,7 @@ export default function MediumNavFooter() {
 			<Divider />
 			<NotificationDialog />
 			<InternalLink
-				className={cn('flex h-10 items-center justify-center rounded-md p-1 hover:bg-brand hover:text-brand-foreground', {
+				className={cn('flex h-9 items-center justify-center rounded-md p-1 hover:bg-brand hover:text-brand-foreground', {
 					'justify-start gap-2 py-2': visible,
 				})}
 				href="/users/@me/setting"

--- a/app/[locale]/(main)/medium-navigation-items.tsx
+++ b/app/[locale]/(main)/medium-navigation-items.tsx
@@ -81,12 +81,12 @@ export function PathGroupElement({ group }: PathGroupElementProps) {
 	const { key, name, paths } = group;
 
 	return (
-		<nav className="flex flex-col" key={key}>
+		<nav className="flex flex-col gap-1" key={key}>
 			{name && (
 				<>
 					<Divider />
 					<NavbarVisible>
-						<span className="px-1 uppercase py-2 font-semibold">{name}</span>
+						<span className="capitalize p-1 font-semibold">{name}</span>
 					</NavbarVisible>
 				</>
 			)}

--- a/app/[locale]/(main)/navbar-link.tsx
+++ b/app/[locale]/(main)/navbar-link.tsx
@@ -29,7 +29,7 @@ export default function NavbarLink({ name, icon, path, regex, filter }: Props) {
 			<TooltipTrigger asChild>
 				<InternalLink
 					className={cn(
-						'flex h-10 items-center text-foreground/60 capitalize justify-center rounded-md p-1 hover:bg-brand hover:text-brand-foreground text-sm',
+						'flex h-9 items-center text-foreground/60 capitalize justify-center rounded-md p-1 hover:bg-brand hover:text-brand-foreground text-sm',
 						{
 							'bg-brand text-brand-foreground': regex.some((r) => currentPath.match(r)),
 							'justify-start gap-2 py-2': visible,

--- a/app/[locale]/(main)/nested-path-element-container.tsx
+++ b/app/[locale]/(main)/nested-path-element-container.tsx
@@ -34,7 +34,7 @@ export function NestedPathElementContainer({ children, segment }: NestedPathElem
 				<AccordionItem className="w-full" value={id}>
 					<AccordionTrigger
 						className={cn(
-							'flex h-10 items-center justify-center text-base text-foreground/60 gap-0 rounded-md p-1 hover:bg-brand hover:text-brand-foreground',
+							'flex h-9 items-center justify-center text-base text-foreground/60 gap-0 rounded-md p-1 hover:bg-brand hover:text-brand-foreground',
 							{
 								'justify-start gap-2 py-2': visible,
 								'bg-brand': regex.some((r) => currentPath.match(r)) && !visible,

--- a/app/[locale]/docs/doc-type.ts
+++ b/app/[locale]/docs/doc-type.ts
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import p from 'path';
-import { cache } from 'react';
 import removeMd from 'remove-markdown';
 
 export type Doc = {
@@ -72,7 +71,7 @@ export function readDocsByLocale(locale: string) {
 	return readDocs(localeFolder);
 }
 
-const readDocs = cache((localeFolder: string): Doc[] => {
+const readDocs = (localeFolder: string): Doc[] => {
 	if (!fs.existsSync(localeFolder)) {
 		return [];
 	}
@@ -119,7 +118,7 @@ const readDocs = cache((localeFolder: string): Doc[] => {
 		.filter(Boolean) //
 		.reduce<Doc[]>((prev, curr) => (Array.isArray(curr) ? [...prev, ...curr] : [...prev, curr]), [])
 		.sort((a, b) => (a.metadata.position ?? 0) - (b.metadata.position ?? 0));
-});
+};
 
 function readDocFile(path: string, filename: string): Doc {
 	if (!fs.existsSync(path)) {

--- a/i18n/server.ts
+++ b/i18n/server.ts
@@ -71,17 +71,19 @@ const initI18next = async (language: Locale, namespace?: string | string[]) => {
 	return i18nInstance;
 };
 
-export const getTranslation = cache(
-	async (locale: Locale, namespace: string | string[] = 'common', options: { keyPrefix?: string } = {}) => {
-		const language = locales.includes(locale as any) ? locale : defaultLocale;
-		namespace = Array.isArray(namespace)? namespace.map(n => n.toLowerCase()) : namespace.toLowerCase();
+export const getTranslation = async (
+	locale: Locale,
+	namespace: string | string[] = 'common',
+	options: { keyPrefix?: string } = {},
+) => {
+	const language = locales.includes(locale as any) ? locale : defaultLocale;
+	namespace = Array.isArray(namespace) ? namespace.map((n) => n.toLowerCase()) : namespace.toLowerCase();
 
-		const i18nextInstance = await initI18next(language, namespace);
-		const t = i18nextInstance.getFixedT(language, namespace, options.keyPrefix)
+	const i18nextInstance = await initI18next(language, namespace);
+	const t = i18nextInstance.getFixedT(language, namespace, options.keyPrefix);
 
-		return {
-			t: (key: string, options?: any) => t(key.toLowerCase(), options) as string,
-			i18n: i18nextInstance,
-		};
-	},
-);
+	return {
+		t: (key: string, options?: any) => t(key.toLowerCase(), options) as string,
+		i18n: i18nextInstance,
+	};
+};


### PR DESCRIPTION
The React cache was removed from the `readDocs` and `getTranslation` functions to simplify the code and avoid unnecessary caching. This change improves maintainability and reduces complexity without altering the core functionality.