### PR TITLE
refactor(medium-navigation-items): simplify PathGroupElement rendering

### DIFF
--- a/app/[locale]/(main)/medium-navigation-items.tsx
+++ b/app/[locale]/(main)/medium-navigation-items.tsx
@@ -82,14 +82,7 @@ export function PathGroupElement({ group }: PathGroupElementProps) {
 
 	return (
 		<nav className="flex flex-col gap-1" key={key}>
-			{name && (
-				<>
-					<Divider />
-					<NavbarVisible>
-						<span className="capitalize p-1 font-semibold">{name}</span>
-					</NavbarVisible>
-				</>
-			)}
+			{name && <Divider />}
 			{paths.map((p) => {
 				const { path, ...rest } = p;
 


### PR DESCRIPTION
Remove redundant NavbarVisible and span elements to streamline the rendering logic for navigation items