### PR TITLE
style(tailwind): update font-family configuration for icons

### DIFF
--- a/components/ui/form.tsx
+++ b/components/ui/form.tsx
@@ -79,7 +79,7 @@ const FormLabel = React.forwardRef<
 >(({ className, ...props }, ref) => {
 	const { error, formItemId } = useFormField();
 
-	return <Label ref={ref} className={cn(error && 'text-destructive', className)} htmlFor={formItemId} {...props} />;
+	return <Label ref={ref} className={cn(error && 'text-destructive-foreground', className)} htmlFor={formItemId} {...props} />;
 });
 FormLabel.displayName = 'FormLabel';
 
@@ -119,7 +119,7 @@ const FormMessage = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<
 		}
 
 		return (
-			<p ref={ref} id={formMessageId} className={cn('text-[0.8rem] font-medium text-destructive', className)} {...props}>
+			<p ref={ref} id={formMessageId} className={cn('text-[0.8rem] font-medium text-destructive-foreground', className)} {...props}>
 				{body}
 			</p>
 		);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,7 +11,7 @@ module.exports = {
 				screen: ['100vh /* fallback for Opera, IE and etc. */', '100dvh'],
 			},
 			fontFamily: {
-				icon: ['var(--font-icon)'],
+				noto: ['var(--font-icon)','var(--font-noto)', 'sans-serif'],
 			},
 			minHeight: (theme: any) => ({
 				...theme('spacing'),


### PR DESCRIPTION
Extend the font-family configuration for icons to include 'var(--font-noto)' and 'sans-serif' as fallback fonts, improving consistency and ensuring better font rendering across different environments.