### PR TITLE
fix(file-card): correct conditional rendering logic for file data

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -85,8 +85,8 @@ export default async function Root({ children, params }: RootProps) {
 		<html
 			className={cn(
 				'dark h-full w-full overflow-hidden bg-background text-foreground antialiased',
-				noto.variable,
-				icon.variable,
+				noto.className,
+				icon.className,
 				'font-noto',
 			)}
 			lang={locale}

--- a/components/file/file-card.tsx
+++ b/components/file/file-card.tsx
@@ -15,7 +15,7 @@ type Props = {
 export default function FileCard({ file, children, onClick }: Props) {
 	const { data, name, size, directory } = file;
 
-	if (!directory) {
+	if (data !== null) {
 		return <p className="whitespace-pre-line">{data}</p>;
 	}
 


### PR DESCRIPTION
The previous condition `if (!directory)` was incorrectly rendering the file data based on the directory flag. This change updates the condition to `if (data !== null)` to ensure the file data is rendered correctly when it exists, regardless of whether the file is a directory or not.