### PR TITLE
fix: update default log collection and handle null session data

### DIFF
--- a/app/[locale]/(main)/logs/page.client.tsx
+++ b/app/[locale]/(main)/logs/page.client.tsx
@@ -73,7 +73,7 @@ function LiveLog() {
 }
 
 const defaultFilter: Omit<LogPaginationQueryType, 'page' | 'size'> = {
-	collection: 'SERVER',
+	collection: 'SYSTEM',
 	env: 'Prod',
 	ip: '',
 	userId: '',

--- a/context/session.context.tsx
+++ b/context/session.context.tsx
@@ -107,7 +107,9 @@ export function SessionProvider({ locale, children }: { locale: Locale; children
 			status === 'error'
 				? { session: { error }, state: 'unauthenticated' }
 				: status === 'success'
-					? { session: data, state: 'authenticated' }
+					? data
+						? { session: data, state: 'authenticated' }
+						: { session: null, state: 'unauthenticated' }
 					: { session: null, state: 'loading' };
 
 		return {


### PR DESCRIPTION
- Change default log collection from 'SERVER' to 'SYSTEM' to align with system logs
- Add null check for session data to prevent undefined state in session context