### PR TITLE
feat(files): add support for folder creation and update file upload l…

### DIFF
--- a/query/file.ts
+++ b/query/file.ts
@@ -19,8 +19,16 @@ export async function getServerFiles(axios: AxiosInstance, path: string): Promis
 	return result.data;
 }
 
-export async function createServerFile(axios: AxiosInstance, path: string, file: File): Promise<void> {
-	const form = toForm({ file });
+type UploadServerFile =
+	| {
+			file: File;
+	  }
+	| {
+			name: string;
+	  };
+
+export async function createServerFile(axios: AxiosInstance, path: string, body: UploadServerFile): Promise<void> {
+	const form = toForm(body);
 
 	return axios.post(`/files`, form, {
 		params: { path },


### PR DESCRIPTION
…ogic

Extend the `createServerFile` function to handle both file and folder creation by introducing a union type `UploadServerFile`. Add a new `AddFolderDialog` component to allow users to create folders. Update the `AddFileDialog` to align with the new `createServerFile` interface.