### PR TITLE
refactor(tag): replace hyphen with underscore in tag names

### DIFF
--- a/components/tag/multiple-filter-tags.tsx
+++ b/components/tag/multiple-filter-tags.tsx
@@ -45,7 +45,7 @@ export default function MultipleFilerTags({ group, selectedValue, handleTagGroup
 					onClick={() => handleClick(value)}
 				>
 					<TagIcon>{value.icon}</TagIcon>
-					{(!value.icon || showTagName) && <TagName>{`${group.name}-${value.name}`}</TagName>}
+					{(!value.icon || showTagName) && <TagName>{`${group.name}_${value.name}`}</TagName>}
 					{showTagNumber && `(${value.count})`}
 				</button>
 			))}

--- a/components/tag/single-filter-tags.tsx
+++ b/components/tag/single-filter-tags.tsx
@@ -36,7 +36,7 @@ function SingeFilerTags({ group, selectedValue, handleTagGroupChange }: SingeFil
 					onClick={() => handleTagGroupChange(value)}
 				>
 					<TagIcon>{value.icon}</TagIcon>
-					{(!value.icon || showTagName) && <TagName>{`${group.name}-${value.name}`}</TagName>}
+					{(!value.icon || showTagName) && <TagName>{`${group.name}_${value.name}`}</TagName>}
 					{showTagNumber && `(${value.count})`}
 				</button>
 			))}

--- a/components/tag/tag-badge.tsx
+++ b/components/tag/tag-badge.tsx
@@ -38,7 +38,7 @@ function TagBadge({ tag: tagDetail, className, onDelete, ...props }: TagBadgePro
 			{...props}
 		>
 			<TagIcon>{icon}</TagIcon>
-			<TagName>{`${name}-${value}`}</TagName>
+			<TagName>{`${name}_${value}`}</TagName>
 			{hasDelete && <XIcon className="size-4 group-hover:block group-focus:block hidden" />}
 		</div>
 	);

--- a/components/tag/tag-card.tsx
+++ b/components/tag/tag-card.tsx
@@ -39,7 +39,7 @@ function TagCard({ tag: tagDetail, className, onDelete, ...props }: TagCardProps
 		>
 			<TagTooltip value={value}>
 				<TagIcon>{icon}</TagIcon>
-				<TagName>{`${name}-${value}`}</TagName>
+				<TagName>{`${name}_${value}`}</TagName>
 			</TagTooltip>
 			{hasDelete && <XIcon className="size-4" />}
 		</span>


### PR DESCRIPTION
The change replaces hyphens with underscores in tag names across multiple components to maintain consistency and improve readability. This modification affects TagCard, TagBadge, MultipleFilterTags, and SingleFilterTags components.