### PR TITLE
fix: convert RAM usage values to bytes for accurate chart display

### DIFF
--- a/app/[locale]/(main)/admin/setting/tags/page.client.tsx
+++ b/app/[locale]/(main)/admin/setting/tags/page.client.tsx
@@ -129,7 +129,7 @@ function GroupCard({ group }: GroupCardProps) {
 	}
 	return (
 		<div className="p-4 bg-card rounded-lg grid md:grid-cols-[128px_1fr] gap-2 border">
-			<Tran className="text-lg" text={name} />
+			<Tran className="text-lg" text={`tags.group-${name}`} />
 			<div className="flex gap-2 flex-wrap">
 				<DndProvider backend={HTML5Backend}>
 					{categories
@@ -213,7 +213,7 @@ function GroupCategoryCard({ group, category, isHovered, onDrop, onHover }: Grou
 			ref={ref}
 			data-handler-id={handlerId}
 		>
-			<Tran className="text-nowrap group-hover:mr-2" text={`tags.${category.name}`} />
+			<Tran className="text-nowrap group-hover:mr-2" text={`tags.${group.name}_${category.name}`} />
 			<DeleteGroupInfoDialog group={group} category={category} />
 		</div>
 	);
@@ -292,11 +292,18 @@ function TagCategoryCard({ category, modId }: TagCategoryCardProps) {
 
 	return (
 		<div className="grid p-4 gap-2 rounded-lg grid-cols-[128px_auto_40px] bg-card items-start border">
-			<Tran className="overflow-hidden text-ellipsis text-lg" style={{ color }} text={name} />
+			<Tran className="overflow-hidden text-ellipsis text-lg" style={{ color }} text={`tags.group-${name}`} />
 			<div className="flex flex-wrap gap-2">
 				<DndProvider backend={HTML5Backend}>
 					{values.map((tag) => (
-						<TagCard key={tag.id} isHovered={hoverId === tag.id} tag={tag} onDrop={onDrop} onHover={setHoverId} />
+						<TagCard
+							key={tag.id}
+							groupName={name}
+							isHovered={hoverId === tag.id}
+							tag={tag}
+							onDrop={onDrop}
+							onHover={setHoverId}
+						/>
 					))}
 					<CreateTagDialog key={modId} categoryId={category.id} modId={modId} />
 				</DndProvider>
@@ -316,12 +323,13 @@ interface DragItem {
 
 type TagCardProps = {
 	tag: TagDto;
+	groupName: string;
 	isHovered: boolean;
 	onDrop: (dragId: number, hoverId: number) => void;
 	onHover: (hoverIndex: number) => void;
 };
 
-function TagCard({ tag, isHovered, onDrop, onHover }: TagCardProps) {
+function TagCard({ tag, groupName, isHovered, onDrop, onHover }: TagCardProps) {
 	const { id, icon, name, categoryId } = tag;
 
 	const ref = useRef<HTMLDivElement>(null);
@@ -373,7 +381,7 @@ function TagCard({ tag, isHovered, onDrop, onHover }: TagCardProps) {
 			data-handler-id={handlerId}
 		>
 			{icon && <Image className="size-6 rounded-lg" width={40} height={40} src={icon} alt={name} />}
-			<Tran text={name} />
+			<Tran text={`tags.${groupName}_${name}`} />
 			<div className="ml-auto">
 				<EllipsisButton variant="ghost" className="p-0 text-muted-foreground">
 					<UpdateTagDialog tag={tag} />

--- a/app/[locale]/(main)/maps/[id]/page.tsx
+++ b/app/[locale]/(main)/maps/[id]/page.tsx
@@ -42,13 +42,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 			type: 'article',
 			title: name,
 			description: `Author: ${user.name} ⬇️\n\n${downloadCount} 👍${likes} 👎${dislikes}\n\nTags: ${tags
-				.map((tag) =>
-					tag.name
-						.split('_')
-						.filter((v) => v)
-						.map((v) => t(v))
-						.join(' '),
-				)
+				.map((tag) => t(tag.name))
 				.join(', ')} \n\n \n\n${description}`,
 			images: `${env.url.image}/maps/${id}${env.imageFormat}`,
 			authors: [`${env.url.image}/users/${userId}`],

--- a/app/[locale]/(main)/schematics/[id]/page.tsx
+++ b/app/[locale]/(main)/schematics/[id]/page.tsx
@@ -21,7 +21,7 @@ const getCachedSchematic = cache((id: string) => serverApi((axios) => getSchemat
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
 	const { id, locale } = await params;
-	const { t } = await getTranslation(locale, ['tags']);
+	const { t } = await getTranslation(locale, 'tags');
 	const schematic = await getCachedSchematic(id);
 
 	if (isError(schematic)) {
@@ -43,13 +43,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 			type: 'article',
 			title: name,
 			description: `Author: ${user.name}\n\n⬇️${downloadCount} 👍${likes} 👎${dislikes} \n\nTags: ${tags
-				.map((tag) =>
-					tag.name
-						.split('_')
-						.filter((v) => v)
-						.map((v) => t(v))
-						.join(' '),
-				)
+				.map((tag) => t(tag.name))
 				.join(', ')} \n\n${description}`,
 			images: `${env.url.image}/schematics/${id}${env.imageFormat}`,
 			authors: [`${env.url.image}/users/${userId}`],

--- a/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
@@ -140,7 +140,7 @@ export default async function Page({ params }: Props) {
 											<Tran text="server.cpu-usage" />
 											<span>{cpuUsage}%</span>
 										</div>
-										<RamUsageChart ramUsage={ramUsage} totalRam={totalRam} />
+										<RamUsageChart ramUsage={ramUsage * 1024 * 1024} totalRam={totalRam * 1024 * 1024} />
 									</div>
 								) : (
 									<Tran text="server.server-is-not-running" />

--- a/components/tag/filter-tags.tsx
+++ b/components/tag/filter-tags.tsx
@@ -9,50 +9,75 @@ import TagGroup from '@/types/response/TagGroup';
 export type FilterTag = { name: string; icon?: string };
 
 type FilterTagProps = {
-  filter: string;
-  filterBy: TagGroup[];
-  tags: TagGroup[];
-  handleTagGroupChange: (group: string, value: FilterTag[]) => void;
+	filter: string;
+	filterBy: TagGroup[];
+	tags: TagGroup[];
+	handleTagGroupChange: (group: string, value: FilterTag[]) => void;
 };
 
 const empty: FilterTag[] = [];
 
 export default function FilterTags({ filter, tags, filterBy, handleTagGroupChange }: FilterTagProps) {
-  const { t } = useI18n('tags');
+	const { t } = useI18n('tags');
 
-  const filteredTags = useMemo(
-    () =>
-      filter.length === 0
-        ? tags.sort((a, b) => a.position - b.position)
-        : tags
-            .sort((a, b) => a.position - b.position)
-            .map((tag) => {
-              const v = { ...tag };
-              v.values = tag.values.filter((value) => t(value.name).toLowerCase().includes(filter.toLowerCase()));
+	const filteredTags = useMemo(
+		() =>
+			filter.length === 0
+				? tags.sort((a, b) => a.position - b.position)
+				: tags
+						.sort((a, b) => a.position - b.position)
+						.map((tag) => {
+							const v = { ...tag };
+							v.values = tag.values.filter((value) =>
+								t(`${tag.name}_${value.name}`).toLowerCase().includes(filter.toLowerCase()),
+							);
 
-              return v;
-            })
-            .filter((tag) => tag.values.length > 0),
-    [filter, tags, t],
-  );
+							return v;
+						})
+						.filter((tag) => tag.values.length > 0),
+		[filter, tags, t],
+	);
 
-  return filteredTags.map((group) => <FilterTagGroup key={group.name} selectedGroup={filterBy.find((value) => value.name === group.name)} group={group} handleTagGroupChange={handleTagGroupChange} />);
+	return filteredTags.map((group) => (
+		<FilterTagGroup
+			key={group.name}
+			selectedGroup={filterBy.find((value) => value.name === group.name)}
+			group={group}
+			handleTagGroupChange={handleTagGroupChange}
+		/>
+	));
 }
 
 type FilterTagGroupProps = {
-  group: TagGroup;
-  selectedGroup?: TagGroup;
-  handleTagGroupChange: (group: string, value: FilterTag[]) => void;
+	group: TagGroup;
+	selectedGroup?: TagGroup;
+	handleTagGroupChange: (group: string, value: FilterTag[]) => void;
 };
 
 const FilterTagGroup = ({ group, selectedGroup, handleTagGroupChange }: FilterTagGroupProps) => {
-  const handleMultipleValueChange = useCallback((value: FilterTag[]) => handleTagGroupChange(group.name, value), [group, handleTagGroupChange]);
+	const handleMultipleValueChange = useCallback(
+		(value: FilterTag[]) => handleTagGroupChange(group.name, value),
+		[group, handleTagGroupChange],
+	);
 
-  const handleSingleValueChange = useCallback((value: FilterTag) => handleTagGroupChange(group.name, value ? [value] : []), [group, handleTagGroupChange]);
+	const handleSingleValueChange = useCallback(
+		(value: FilterTag) => handleTagGroupChange(group.name, value ? [value] : []),
+		[group, handleTagGroupChange],
+	);
 
-  return group.duplicate ? (
-    <MultipleFilerTags key={group.name} group={group} selectedValue={selectedGroup?.values ?? empty} handleTagGroupChange={handleMultipleValueChange} />
-  ) : (
-    <SingeFilerTags key={group.name} group={group} selectedValue={selectedGroup?.values[0]} handleTagGroupChange={handleSingleValueChange} />
-  );
+	return group.duplicate ? (
+		<MultipleFilerTags
+			key={group.name}
+			group={group}
+			selectedValue={selectedGroup?.values ?? empty}
+			handleTagGroupChange={handleMultipleValueChange}
+		/>
+	) : (
+		<SingeFilerTags
+			key={group.name}
+			group={group}
+			selectedValue={selectedGroup?.values[0]}
+			handleTagGroupChange={handleSingleValueChange}
+		/>
+	);
 };

--- a/components/tag/tag-card.tsx
+++ b/components/tag/tag-card.tsx
@@ -37,7 +37,7 @@ function TagCard({ tag: tagDetail, className, onDelete, ...props }: TagCardProps
 			onClick={() => handleOnDelete(tag)}
 			{...props}
 		>
-			<TagTooltip value={value}>
+			<TagTooltip value={`${name}_${value}`}>
 				<TagIcon>{icon}</TagIcon>
 				<TagName>{`${name}_${value}`}</TagName>
 			</TagTooltip>

--- a/components/tag/tag-tooltip.tsx
+++ b/components/tag/tag-tooltip.tsx
@@ -4,23 +4,23 @@ import Tran from '@/components/common/tran';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
 type Props = {
-  value: string;
-  children: ReactNode;
+	value: string;
+	children: ReactNode;
 };
 
 function TagTooltip({ value, children }: Props) {
-  return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span className="flex gap-1 items-center">{children}</span>
-        </TooltipTrigger>
-        <TooltipContent className="bg-foreground normal-case text-background">
-          <Tran text={`tags.${value}.description`} />
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  );
+	return (
+		<TooltipProvider>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<span className="flex gap-1 items-center">{children}</span>
+				</TooltipTrigger>
+				<TooltipContent className="bg-foreground normal-case text-background">
+					<Tran text={`tags.${value}`} />
+				</TooltipContent>
+			</Tooltip>
+		</TooltipProvider>
+	);
 }
 
 export default TagTooltip;


### PR DESCRIPTION
The RamUsageChart component expects values in bytes, but the data was being passed in megabytes. This commit multiplies the ramUsage and totalRam values by 1024 * 1024 to convert them from megabytes to bytes, ensuring the chart displays accurate information.