### PR TITLE
chore: increase request timeout to 3000ms

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -2,7 +2,7 @@ NEXT_PUBLIC_FRONTEND_URL=https://mindustry-tool.com
 NEXT_PUBLIC_BACKEND_URL=https://api.mindustry-tool.com/api/v3
 NEXT_PUBLIC_BACKEND_SOCKET_URL=wss://api.mindustry-tool.com
 NEXT_PUBLIC_CLOUDINARY_IMAGE_URL=https://image.mindustry-tool.com
-NEXT_PUBLIC_REQUEST_TIMEOUT=1000
+NEXT_PUBLIC_REQUEST_TIMEOUT=3000
 
 # NEXT_PUBLIC_FRONTEND_URL=http://localhost:3000
 # NEXT_PUBLIC_BACKEND_URL=http://localhost:8080/api/v3


### PR DESCRIPTION
The request timeout was increased from 1000ms to 3000ms to accommodate slower network conditions and reduce the likelihood of timeout errors in production.