### PR TITLE
chore: increase request timeout to 15000 for production

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -2,7 +2,7 @@ NEXT_PUBLIC_FRONTEND_URL=https://mindustry-tool.com
 NEXT_PUBLIC_BACKEND_URL=https://api.mindustry-tool.com/api/v3
 NEXT_PUBLIC_BACKEND_SOCKET_URL=wss://api.mindustry-tool.com
 NEXT_PUBLIC_CLOUDINARY_IMAGE_URL=https://image.mindustry-tool.com
-NEXT_PUBLIC_REQUEST_TIMEOUT=3000
+NEXT_PUBLIC_REQUEST_TIMEOUT=15000
 
 # NEXT_PUBLIC_FRONTEND_URL=http://localhost:3000
 # NEXT_PUBLIC_BACKEND_URL=http://localhost:8080/api/v3


### PR DESCRIPTION
The request timeout was increased to 15000 to accommodate slower network conditions and improve reliability in production environments.