### PR TITLE
refactor: move http error handling to sonner and clean up toast logic

### DIFF
--- a/action/common.ts
+++ b/action/common.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { AxiosInstance, isAxiosError } from 'axios';
+import { AxiosInstance } from 'axios';
 import { revalidatePath, revalidateTag, unstable_cache, unstable_noStore } from 'next/cache';
 import { cookies } from 'next/headers';
 import { cache } from 'react';
@@ -42,17 +42,8 @@ export async function catchError<T>(axios: AxiosInstance, queryFn: ServerApi<T>)
 		const data = 'queryFn' in queryFn ? await queryFn.queryFn(axios) : await queryFn(axios);
 		return data;
 	} catch (error) {
-		if (isAxiosError(error)) {
-			return {
-				error: {
-					status: error.response?.status,
-					data: error.response?.data,
-					message: error?.message + error.response?.config.url,
-				},
-			};
-		}
 		return {
-			error: JSON.parse(JSON.stringify(error, Object.getOwnPropertyNames(error))),
+			error,
 		};
 	}
 }
@@ -119,7 +110,7 @@ export const getServerApi = async (): Promise<AxiosInstance> => {
 
 		return config;
 	});
-	
+
 	axiosInstance.defaults.headers['Server'] = true;
 
 	return axiosInstance;

--- a/app/[locale]/(main)/(shar)/files/file-list.tsx
+++ b/app/[locale]/(main)/(shar)/files/file-list.tsx
@@ -38,7 +38,7 @@ export default function FileList({ path, filter, setFilePath }: FileListProps) {
 		mutationKey: ['delete-file'],
 		mutationFn: async (path: string) => deleteServerFile(axios, path),
 		onError: (error) => {
-			toast.error(<Tran text="delete-fail" />, { description: error?.message });
+			toast.error(<Tran text="delete-fail" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['server-files', path]);

--- a/app/[locale]/(main)/(shar)/mindustry-gpt/documents/page.tsx
+++ b/app/[locale]/(main)/(shar)/mindustry-gpt/documents/page.tsx
@@ -63,7 +63,7 @@ function AddDocumentButton() {
 			form.reset();
 		},
 		onError(error) {
-			toast.error(<Tran text="upload.fail" />, { description: error?.message });
+			toast.error(<Tran text="upload.fail" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['documents']);

--- a/app/[locale]/(main)/admin/maps/page.client.tsx
+++ b/app/[locale]/(main)/admin/maps/page.client.tsx
@@ -31,7 +31,7 @@ export default function Client() {
 			toast.success(<Tran text="delete-success" />);
 		},
 		onError: (error) => {
-			toast.error(<Tran text="delete-fail" />, { description: error?.message });
+			toast.error(<Tran text="delete-fail" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['maps']);

--- a/app/[locale]/(main)/admin/schematics/page.client.tsx
+++ b/app/[locale]/(main)/admin/schematics/page.client.tsx
@@ -30,7 +30,7 @@ export default function Client() {
 			toast.success(<Tran text="delete-success" />);
 		},
 		onError: (error) => {
-			toast.error(<Tran text="delete-fail" />, { description: error?.message });
+			toast.error(<Tran text="delete-fail" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['schematics']);

--- a/app/[locale]/(main)/admin/setting/(users)/change-role.dialog.tsx
+++ b/app/[locale]/(main)/admin/setting/(users)/change-role.dialog.tsx
@@ -12,6 +12,7 @@ import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { useMe, useSession } from '@/context/session.context';
 import useClientApi from '@/hooks/use-client';
 import useQueriesData from '@/hooks/use-queries-data';
+import { isError } from '@/lib/error';
 import { groupBy } from '@/lib/utils';
 import { getAuthorities } from '@/query/authorities';
 import { changeRoles, getRoles } from '@/query/role';
@@ -20,7 +21,6 @@ import { Authority, Role } from '@/types/response/Role';
 import { User } from '@/types/response/User';
 
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { isError } from '@/lib/error';
 
 type DialogProps = {
 	user: User;
@@ -77,7 +77,7 @@ export function ChangeRoleDialog({ user }: DialogProps) {
 		mutationKey: ['update-user-role', id],
 		mutationFn: async (roleIds: number[]) => changeRoles(axios, { userId: id, roleIds }),
 		onError: (error) => {
-			toast.error(<Tran text="error" />, { description: error?.message });
+			toast.error(<Tran text="error" />, { error });
 			setSelectedRoles(roles);
 		},
 		onSettled: () => {
@@ -89,7 +89,7 @@ export function ChangeRoleDialog({ user }: DialogProps) {
 		mutationFn: async (authorityIds: string[]) => changeAuthorities(axios, { userId: id, authorityIds }),
 		mutationKey: ['update-user-authority', id],
 		onError: (error) => {
-			toast.error(<Tran text="error" />, { description: error?.message });
+			toast.error(<Tran text="error" />, { error });
 
 			setSelectedAuthorities(authorities);
 		},

--- a/app/[locale]/(main)/admin/setting/image/page.tsx
+++ b/app/[locale]/(main)/admin/setting/image/page.tsx
@@ -165,7 +165,7 @@ function DeleteFileAndFolderButton({ path }: { path: string }) {
 					queryClient.invalidateQueries({ queryKey: ['images'] });
 					toast.success('Image deleted successfully');
 				} catch (error: any) {
-					toast.error('Failed to delete image', { description: error?.message });
+					toast.error('Failed to delete image', { error });
 				}
 			}}
 		/>
@@ -202,7 +202,7 @@ function CreateFolderDialog({ path }: { path: string }) {
 			queryClient.invalidateQueries({ queryKey: ['images'] });
 		},
 		onError: (error: any) => {
-			toast.error('Failed to create folder', { description: error?.message });
+			toast.error('Failed to create folder', { error });
 		},
 	});
 
@@ -290,7 +290,7 @@ function UploadButton({ path }: { path: string }) {
 				delete updated[file.name];
 				return updated;
 			});
-			toast.error(`Failed to upload "${file.name}"`, { description: error?.message });
+			toast.error(`Failed to upload "${file.name}"`, { error });
 		},
 	});
 

--- a/app/[locale]/(main)/admin/setting/mods/create-mod.dialog.tsx
+++ b/app/[locale]/(main)/admin/setting/mods/create-mod.dialog.tsx
@@ -45,7 +45,7 @@ export default function CreateModDialog() {
 			form.reset();
 			setOpen(false);
 		},
-		onError: (error) => toast.error(<Tran text="upload.fail" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="upload.fail" />, { error }),
 
 		onSettled: () => {
 			invalidateByKey(['mods']);

--- a/app/[locale]/(main)/admin/setting/mods/update-mod.dialog.tsx
+++ b/app/[locale]/(main)/admin/setting/mods/update-mod.dialog.tsx
@@ -49,7 +49,7 @@ export default function UpdateModDialog({ mod }: Props) {
 			form.reset();
 			setOpen(false);
 		},
-		onError: (error) => toast.error(<Tran text="delete.fail" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="delete.fail" />, { error }),
 
 		onSettled: () => {
 			invalidateByKey(['mods']);

--- a/app/[locale]/(main)/admin/setting/notifications/page.client.tsx
+++ b/app/[locale]/(main)/admin/setting/notifications/page.client.tsx
@@ -45,7 +45,7 @@ export default function PageClient() {
 			toast.success(<Tran text="notification.send-success" />);
 		},
 		onError: (error) => {
-			toast.error(<Tran text="notification.send-fail" />, { description: error?.message });
+			toast.error(<Tran text="notification.send-fail" />, { error });
 		},
 	});
 

--- a/app/[locale]/(main)/admin/setting/roles/change-role-authority.dialog.tsx
+++ b/app/[locale]/(main)/admin/setting/roles/change-role-authority.dialog.tsx
@@ -56,7 +56,7 @@ export default function ChangeRoleAuthorityDialog({ role }: Props) {
 			revalidate({ path: '/users' });
 		},
 		onError: (error) => {
-			toast.error('Error', { description: error?.message });
+			toast.error('Error', { error });
 			setSelectedAuthorities(authorities);
 		},
 		mutationKey: ['update-role-authority', roleId],

--- a/app/[locale]/(main)/admin/setting/roles/create-role.dialog.tsx
+++ b/app/[locale]/(main)/admin/setting/roles/create-role.dialog.tsx
@@ -45,7 +45,7 @@ export default function CreateRoleDialog() {
 			form.reset();
 			setOpen(false);
 		},
-		onError: (error) => toast.error(<Tran text="upload.fail" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="upload.fail" />, { error }),
 		onSettled: () => {
 			invalidateByKey(['roles']);
 			revalidate({ path: '/users' });

--- a/app/[locale]/(main)/admin/setting/roles/delete-role.button.tsx
+++ b/app/[locale]/(main)/admin/setting/roles/delete-role.button.tsx
@@ -30,7 +30,7 @@ export default function DeleteRoleButton({ role }: Props) {
 		onSuccess: () => {
 			toast.success(<Tran text="upload.success" />);
 		},
-		onError: (error) => toast.error(<Tran text="upload.fail" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="upload.fail" />, { error }),
 		onSettled: () => {
 			invalidateByKey(['roles']);
 			revalidate({ path: '/roles' });

--- a/app/[locale]/(main)/admin/setting/roles/role-list.tsx
+++ b/app/[locale]/(main)/admin/setting/roles/role-list.tsx
@@ -5,6 +5,8 @@ import React from 'react';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 
+import RoleCard from '@/app/[locale]/(main)/admin/setting/roles/role-card';
+
 import Tran from '@/components/common/tran';
 import { toast } from '@/components/ui/sonner';
 
@@ -14,7 +16,6 @@ import { getRoles, moveRole } from '@/query/role';
 import { Role, RoleWithAuthorities } from '@/types/response/Role';
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import RoleCard from '@/app/[locale]/(main)/admin/setting/roles/role-card';
 
 type Props = {
 	roles: RoleWithAuthorities[];
@@ -33,7 +34,7 @@ export default function RoleList({ roles, bestRole }: Props) {
 
 			return moveRole(axios, payload);
 		},
-		onError: (error) => toast.error(<Tran text="upload.fail" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="upload.fail" />, { error }),
 		onSettled: () => {
 			invalidateByKey(['roles']);
 		},

--- a/app/[locale]/(main)/admin/setting/roles/update-role.dialog.tsx
+++ b/app/[locale]/(main)/admin/setting/roles/update-role.dialog.tsx
@@ -46,7 +46,7 @@ export default function UpdateRoleDialog({ role }: Props) {
 			form.reset();
 			setOpen(false);
 		},
-		onError: (error) => toast.error(<Tran text="upload.fail" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="upload.fail" />, { error }),
 		onSettled: () => {
 			invalidateByKey(['roles']);
 			revalidate({ path: '/' });

--- a/app/[locale]/(main)/admin/setting/tags/create-group-info.dialog.tsx
+++ b/app/[locale]/(main)/admin/setting/tags/create-group-info.dialog.tsx
@@ -33,7 +33,7 @@ export default function CreateGroupInfoPopover({ group }: Props) {
 		onSuccess: () => {
 			toast.success(<Tran text="upload.success" />);
 		},
-		onError: (error) => toast.error(<Tran text="upload.fail" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="upload.fail" />, { error }),
 		onSettled: () => {
 			invalidateByKey(['tag-category']);
 			invalidateByKey(['tag-group']);

--- a/app/[locale]/(main)/admin/setting/tags/create-tag-category.dialog.tsx
+++ b/app/[locale]/(main)/admin/setting/tags/create-tag-category.dialog.tsx
@@ -46,7 +46,7 @@ export default function CreateTagCategoryDialog() {
 			form.reset();
 			setOpen(false);
 		},
-		onError: (error) => toast.error(<Tran text="upload.fail" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="upload.fail" />, { error }),
 
 		onSettled: () => {
 			invalidateByKey(['tag-category']);

--- a/app/[locale]/(main)/admin/setting/tags/create-tag.dialog.tsx
+++ b/app/[locale]/(main)/admin/setting/tags/create-tag.dialog.tsx
@@ -52,7 +52,7 @@ export default function CreateTagDialog({ categoryId, modId }: Props) {
 			form.reset();
 			setOpen(false);
 		},
-		onError: (error) => toast.error(<Tran text="upload.fail" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="upload.fail" />, { error }),
 
 		onSettled: () => {
 			invalidateByKey(['tags-detail']);

--- a/app/[locale]/(main)/admin/setting/tags/delete-group-info.dialog.tsx
+++ b/app/[locale]/(main)/admin/setting/tags/delete-group-info.dialog.tsx
@@ -26,7 +26,7 @@ export default function DeleteGroupInfoDialog({ group, category }: Props) {
 		onSuccess: () => {
 			toast.success(<Tran text="delete.success" />);
 		},
-		onError: (error) => toast.error(<Tran text="delete.fail" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="delete.fail" />, { error }),
 		onSettled: () => {
 			invalidateByKey(['tag-category']);
 			invalidateByKey(['tag-group']);

--- a/app/[locale]/(main)/admin/setting/tags/delete-tag-category.dialog.tsx
+++ b/app/[locale]/(main)/admin/setting/tags/delete-tag-category.dialog.tsx
@@ -26,7 +26,7 @@ export default function DeleteTagCategoryDialog({ category }: Props) {
 			toast.success(<Tran text="delete-success" />);
 		},
 		onError: (error) => {
-			toast.error(<Tran text="delete-fail" />, { description: error?.message });
+			toast.error(<Tran text="delete-fail" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['tags-detail']);

--- a/app/[locale]/(main)/admin/setting/tags/delete-tag.dialog.tsx
+++ b/app/[locale]/(main)/admin/setting/tags/delete-tag.dialog.tsx
@@ -26,7 +26,7 @@ export default function DeleteTagDialog({ tag }: Props) {
 			toast.success(<Tran text="delete-success" />);
 		},
 		onError: (error) => {
-			toast.error(<Tran text="delete-fail" />, { description: error?.message });
+			toast.error(<Tran text="delete-fail" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['tags-detail']);

--- a/app/[locale]/(main)/admin/setting/tags/page.client.tsx
+++ b/app/[locale]/(main)/admin/setting/tags/page.client.tsx
@@ -109,7 +109,7 @@ function GroupCard({ group }: GroupCardProps) {
 				updateGroupInfo(axios, group.id, category2.id, { position: category2Position }),
 			]);
 		},
-		onError: (error) => toast.error(<Tran text="upload.fail" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="upload.fail" />, { error }),
 		onSettled: () => {
 			invalidateByKey(['tag-group']);
 		},
@@ -271,7 +271,7 @@ function TagCategoryCard({ category, modId }: TagCategoryCardProps) {
 
 			return Promise.all([updateTag(axios, tag1.id, tag1), updateTag(axios, tag2.id, tag2)]);
 		},
-		onError: (error) => toast.error(<Tran text="upload.fail" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="upload.fail" />, { error }),
 		onSettled: () => {
 			invalidateByKey(['tags-detail']);
 		},

--- a/app/[locale]/(main)/admin/setting/tags/update-tag-category.dialog.tsx
+++ b/app/[locale]/(main)/admin/setting/tags/update-tag-category.dialog.tsx
@@ -47,7 +47,7 @@ export default function UpdateTagCategoryDialog({ category }: Props) {
 			form.reset();
 			setOpen(false);
 		},
-		onError: (error) => toast.error(<Tran text="upload.fail" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="upload.fail" />, { error }),
 
 		onSettled: () => {
 			invalidateByKey(['tag-category']);

--- a/app/[locale]/(main)/admin/setting/tags/update-tag.dialog.tsx
+++ b/app/[locale]/(main)/admin/setting/tags/update-tag.dialog.tsx
@@ -70,7 +70,7 @@ export default function UpdateTagDialog({ tag }: Props) {
 			form.reset();
 			setOpen(false);
 		},
-		onError: (error) => toast.error(<Tran text="upload.fail" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="upload.fail" />, { error }),
 
 		onSettled: () => {
 			invalidateByKey(['tags-detail']);

--- a/app/[locale]/(main)/logs/page.client.tsx
+++ b/app/[locale]/(main)/logs/page.client.tsx
@@ -115,6 +115,7 @@ function StaticLog() {
 							label: item,
 							value: item,
 						}))}
+						searchBar={false}
 						onChange={(collection) => setFilter({ collection: collection ?? 'SERVER' })}
 					/>
 					<ComboBox<'Prod' | 'Dev'>

--- a/app/[locale]/(main)/maps/[id]/page.tsx
+++ b/app/[locale]/(main)/maps/[id]/page.tsx
@@ -8,7 +8,7 @@ import { serverApi } from '@/action/common';
 import env from '@/constant/env';
 import { Locale } from '@/i18n/config';
 import { getTranslation } from '@/i18n/server';
-import { isError } from '@/lib/error';
+import { getErrorMessage, isError } from '@/lib/error';
 import { formatTitle, generateAlternate } from '@/lib/utils';
 import { getMap } from '@/query/map';
 import { getUser } from '@/query/user';
@@ -32,7 +32,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 	const user = await serverApi((axios) => getUser(axios, { id: userId }));
 
 	if (isError(user)) {
-		return { title: 'Error', description: user.error?.message };
+		return { title: 'Error', description: getErrorMessage(user) };
 	}
 
 	return {

--- a/app/[locale]/(main)/notification.form.tsx
+++ b/app/[locale]/(main)/notification.form.tsx
@@ -128,7 +128,7 @@ function MarkAsReadButton({ notification }: MarkAsReadButtonProps) {
 			updateById<Notification>(['notifications'], id, (prev) => ({ ...prev, read: true }));
 		},
 		onError: (error) => {
-			toast.error(<Tran text="notification.mark-as-read-failed" />, { description: error?.message });
+			toast.error(<Tran text="notification.mark-as-read-failed" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['notifications']);
@@ -157,7 +157,7 @@ function DeleteButton({ notification }: MarkAsReadButtonProps) {
 		},
 
 		onError: (error) => {
-			toast.error(<Tran text="notification.delete-failed" />, { description: error?.message });
+			toast.error(<Tran text="notification.delete-failed" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['notifications']);
@@ -183,7 +183,7 @@ function DeleteAllButton() {
 			toast.success(<Tran text="notification.delete-all-success" />);
 		},
 		onError: (error) => {
-			toast.error(<Tran text="notification.delete-all-failed" />, { description: error?.message });
+			toast.error(<Tran text="notification.delete-all-failed" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['notifications']);
@@ -231,7 +231,7 @@ function MarkAsReadAllButton() {
 			toast.success(<Tran text="notification.mark-as-read-all-success" />);
 		},
 		onError: (error) => {
-			toast.error(<Tran text="notification.mark-as-read-all-failed" />, { description: error?.message });
+			toast.error(<Tran text="notification.mark-as-read-all-failed" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['notifications']);

--- a/app/[locale]/(main)/plugins/add-plugin.dialog.tsx
+++ b/app/[locale]/(main)/plugins/add-plugin.dialog.tsx
@@ -68,7 +68,7 @@ function AddPluginForm() {
 			form.reset();
 		},
 		onError(error) {
-			toast.error(<Tran text="upload.fail" />, { description: error?.message });
+			toast.error(<Tran text="upload.fail" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['plugins']);

--- a/app/[locale]/(main)/schematics/[id]/page.tsx
+++ b/app/[locale]/(main)/schematics/[id]/page.tsx
@@ -8,7 +8,7 @@ import { serverApi } from '@/action/common';
 import env from '@/constant/env';
 import { Locale } from '@/i18n/config';
 import { getTranslation } from '@/i18n/server';
-import { isError } from '@/lib/error';
+import { getErrorMessage, isError } from '@/lib/error';
 import { formatTitle, generateAlternate } from '@/lib/utils';
 import { getSchematic } from '@/query/schematic';
 import { getUser } from '@/query/user';
@@ -33,7 +33,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 	const user = await serverApi((axios) => getUser(axios, { id: userId }));
 
 	if (isError(user)) {
-		return { title: 'Error', description: user.error?.message };
+		return { title: 'Error', description: getErrorMessage(user) };
 	}
 
 	return {

--- a/app/[locale]/(main)/server-managers/[id]/page.tsx
+++ b/app/[locale]/(main)/server-managers/[id]/page.tsx
@@ -106,11 +106,10 @@ function ResetTokenButton({ id }: ResetTokenButtonProps) {
 
 	const { mutate, isPending } = useMutation({
 		mutationKey: ['reset-token'],
-		mutationFn: async () =>
-			toast.promise(resetTokenServerManager(axios, id), {
-				success: <Tran text="server.reset-token-success" />,
-				error: (error) => <Tran text="error" args={{ message: error?.message }} />,
-			}),
+		mutationFn: async () => resetTokenServerManager(axios, id),
+		onSuccess: () => toast.success(<Tran text="server.reset-token-success" />),
+		onError: (error) => toast.error(<Tran text="server.shutdown-fail" />, { error }),
+
 		onSettled: () => {
 			invalidateByKey(['server-manager']);
 		},

--- a/app/[locale]/(main)/servers/[id]/admin/add-admin-dialog.tsx
+++ b/app/[locale]/(main)/servers/[id]/admin/add-admin-dialog.tsx
@@ -11,7 +11,6 @@ import ScrollContainer from '@/components/common/scroll-container';
 import Tran from '@/components/common/tran';
 import { SearchBar, SearchInput } from '@/components/search/search-input';
 import { Dialog, DialogContent, DialogDescription, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
 import { toast } from '@/components/ui/sonner';
 import UserCard from '@/components/user/user-card';
 
@@ -87,7 +86,7 @@ function AddAdminUserCard({ id, user }: UserCardProps) {
 	const { invalidateByKey } = useQueriesData();
 	const { mutate, isPending } = useMutation({
 		mutationFn: async (userId: string) => createServerAdmin(axios, id, userId),
-		onError: (error) => toast.error(<Tran text="error" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="error" />, { error }),
 		onSettled: () => invalidateByKey(['server']),
 	});
 

--- a/app/[locale]/(main)/servers/[id]/admin/server-admin-card.tsx
+++ b/app/[locale]/(main)/servers/[id]/admin/server-admin-card.tsx
@@ -26,7 +26,7 @@ export default function ServerAdminCard({ id, admin }: ServerAdminCardProps) {
 	const { invalidateByKey } = useQueriesData();
 	const { mutate, isPending, isIdle } = useMutation({
 		mutationFn: async () => deleteServerAdmin(axios, id, admin.id),
-		onError: (error) => toast.error(<Tran text="error" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="error" />, { error }),
 		onSettled: () => invalidateByKey(['server']),
 	});
 

--- a/app/[locale]/(main)/servers/[id]/environments/page.client.tsx
+++ b/app/[locale]/(main)/servers/[id]/environments/page.client.tsx
@@ -88,7 +88,7 @@ function ServerEnvCard({ id, env }: ServerEnvCardProps) {
 	const { invalidateByKey } = useQueriesData();
 	const { mutate, isPending } = useMutation({
 		mutationFn: async () => deleteServerEnv(axios, id, env.id),
-		onError: (error) => toast.error(<Tran text="error" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="error" />, { error }),
 		onSuccess: () => {
 			form.reset();
 		},
@@ -175,7 +175,7 @@ function AddEnvCard({ id }: AddEnvCardProps) {
 	const { invalidateByKey } = useQueriesData();
 	const { mutate, isPending } = useMutation({
 		mutationFn: async (data: z.infer<typeof CreateServerEnvSchema>) => createServerEnv(axios, id, data),
-		onError: (error) => toast.error(<Tran text="error" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="error" />, { error }),
 		onSuccess: () => {
 			form.reset();
 		},

--- a/app/[locale]/(main)/servers/[id]/files/file-list.tsx
+++ b/app/[locale]/(main)/servers/[id]/files/file-list.tsx
@@ -39,7 +39,7 @@ export default function FileList({ id, path, filter, setFilePath }: FileListProp
 		mutationKey: ['delete-file'],
 		mutationFn: async (path: string) => deleteServerFile(axios, id, path),
 		onError: (error) => {
-			toast.error(<Tran text="delete-fail" />, { description: error?.message });
+			toast.error(<Tran text="delete-fail" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['server', id, 'server-files', path]);

--- a/app/[locale]/(main)/servers/[id]/maps/add-map-dialog.tsx
+++ b/app/[locale]/(main)/servers/[id]/maps/add-map-dialog.tsx
@@ -45,7 +45,7 @@ export default function AddMapDialog({ serverId }: AddMapDialogProps) {
 			setAdded((prev) => [...prev, mapId]);
 		},
 		onError: (error) => {
-			toast.error(<Tran text="interval-server.add-map-fail" />, { description: error?.message });
+			toast.error(<Tran text="interval-server.add-map-fail" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['servers', serverId, 'maps']);

--- a/app/[locale]/(main)/servers/[id]/plugins/add-plugin-dialog.tsx
+++ b/app/[locale]/(main)/servers/[id]/plugins/add-plugin-dialog.tsx
@@ -42,7 +42,7 @@ export default function AddPluginDialog({ serverId }: AddPluginDialogProps) {
 			setAdded((prev) => [...prev, pluginId]);
 		},
 		onError: (error) => {
-			toast.error(<Tran text="interval-server.add-plugin-fail" />, { description: error?.message });
+			toast.error(<Tran text="interval-server.add-plugin-fail" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['servers', serverId, 'plugins']);

--- a/app/[locale]/(main)/servers/[id]/remove-server-button.tsx
+++ b/app/[locale]/(main)/servers/[id]/remove-server-button.tsx
@@ -4,7 +4,16 @@ import React from 'react';
 
 import { Hidden } from '@/components/common/hidden';
 import Tran from '@/components/common/tran';
-import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog';
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
 import { toast } from '@/components/ui/sonner';
 
@@ -23,15 +32,11 @@ export default function RemoveServerButton({ id }: Props) {
 
 	const { mutate, isPending } = useMutation({
 		mutationKey: ['servers'],
-		mutationFn: async () =>
-			toast.promise(removeServer(axios, id), {
-				loading: <Tran text="server.shutting-down" />,
-				success: <Tran text="server.remove-success" />,
-				error: (error) => ({ title: <Tran text="server.remove-fail" />, description: error?.message }),
-			}),
-		onSettled: () => {
-			revalidate({ path: '/servers' });
-		},
+		mutationFn: async () => removeServer(axios, id),
+		onMutate: () => toast.loading(<Tran text="server.shutting-down" />),
+		onSuccess: (_data, _variable, id) => toast.success(<Tran text="server.remove-success" />, { id }),
+		onError: (error, _variable, id) => toast.error(<Tran text="server.remove-fail" />, { error, id }),
+		onSettled: () => revalidate({ path: '/servers' }),
 	});
 
 	return (

--- a/app/[locale]/(main)/servers/[id]/setting/delete-setting-button.tsx
+++ b/app/[locale]/(main)/servers/[id]/setting/delete-setting-button.tsx
@@ -47,7 +47,7 @@ function DeleteServerButton({ id }: ServerSettingButtonProps) {
 
 			router.push('/servers');
 		},
-		onError: (error) => toast.error(<Tran text="delete-fail" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="delete-fail" />, { error }),
 		onSettled: () => {
 			revalidate({ path: '/servers' });
 			invalidateByKey(['servers']);
@@ -95,7 +95,7 @@ function TransferServerButton({ id }: ServerSettingButtonProps) {
 
 			router.push('/servers');
 		},
-		onError: (error) => toast.error(<Tran text="transfer-fail" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="transfer-fail" />, { error }),
 		onSettled: () => {
 			revalidate({ path: '/servers' });
 			invalidateByKey(['servers']);

--- a/app/[locale]/(main)/servers/[id]/setting/server-update-admin-form.tsx
+++ b/app/[locale]/(main)/servers/[id]/setting/server-update-admin-form.tsx
@@ -42,11 +42,10 @@ export default function ServerUpdateAdminForm({ server }: Props) {
 
 	const { mutate, isPending } = useMutation({
 		mutationKey: ['servers'],
-		mutationFn: (data: PutServerPortRequest) =>
-			toast.promise(updateServerPort(axios, id, data), {
-				error: (error) => ({ title: <Tran text="update.fail" />, description: error?.message }),
-				success: <Tran text="update.success" />,
-			}),
+		mutationFn: (data: PutServerPortRequest) => updateServerPort(axios, id, data),
+		onSuccess: (_data) => toast.success(<Tran text="update.success" />),
+		onError: (error) => toast.error(<Tran text="update.fail" />, { error }),
+
 		onSettled: () => {
 			invalidateByKey(['servers']);
 			revalidate({ path: '/[locale]/(main)/servers' });

--- a/app/[locale]/(main)/servers/[id]/setting/server-update-form.tsx
+++ b/app/[locale]/(main)/servers/[id]/setting/server-update-form.tsx
@@ -44,7 +44,7 @@ export default function ServerUpdateForm({ server }: Props) {
 			toast.success(<Tran text="update.success" />);
 			revalidate({ path: '/servers' });
 		},
-		onError: (error) => toast.error(<Tran text="update.fail" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="update.fail" />, { error }),
 		onSettled: () => {
 			invalidateByKey(['servers']);
 			revalidate({ path: '/[locale]/(main)/servers' });

--- a/app/[locale]/(main)/servers/[id]/shutdown-server-button.tsx
+++ b/app/[locale]/(main)/servers/[id]/shutdown-server-button.tsx
@@ -4,7 +4,16 @@ import React from 'react';
 
 import { Hidden } from '@/components/common/hidden';
 import Tran from '@/components/common/tran';
-import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog';
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
 import { toast } from '@/components/ui/sonner';
 
@@ -23,15 +32,11 @@ export default function ShutdownServerButton({ id }: Props) {
 
 	const { mutate, isPending } = useMutation({
 		mutationKey: ['servers'],
-		mutationFn: async () =>
-			toast.promise(shutdownServer(axios, id), {
-				loading: <Tran text="server.shutting-down" />,
-				success: <Tran text="server.shutdown-success" />,
-				error: (error) => ({ title: <Tran text="server.shutdown-fail" />, description: error?.message }),
-			}),
-		onSettled: () => {
-			revalidate({ path: '/servers' });
-		},
+		mutationFn: async () => shutdownServer(axios, id),
+		onMutate: () => toast.loading(<Tran text="server.shutting-down" />),
+		onSuccess: (_data, _variable, id) => toast.success(<Tran text="server.shutdown-success" />, { id }),
+		onError: (error, _variable, id) => toast.error(<Tran text="server.shutdown-fail" />, { error, id }),
+		onSettled: () => revalidate({ path: '/servers' }),
 	});
 
 	return (

--- a/app/[locale]/(main)/servers/[id]/stop-server-button.tsx
+++ b/app/[locale]/(main)/servers/[id]/stop-server-button.tsx
@@ -4,7 +4,16 @@ import React from 'react';
 
 import { Hidden } from '@/components/common/hidden';
 import Tran from '@/components/common/tran';
-import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog';
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
 import { toast } from '@/components/ui/sonner';
 
@@ -23,15 +32,11 @@ export default function StopServerButton({ id }: Props) {
 
 	const { mutate, isPending } = useMutation({
 		mutationKey: ['servers'],
-		mutationFn: async () =>
-			toast.promise(stopServer(axios, id), {
-				loading: <Tran text="server.stopping" />,
-				success: <Tran text="server.stop-success" />,
-				error: (error) => ({ title: <Tran text="server.stop-fail" />, description: error?.message }),
-			}),
-		onSettled: () => {
-			revalidate({ path: '/servers' });
-		},
+		mutationFn: async () => stopServer(axios, id),
+		onMutate: () => toast.loading(<Tran text="server.stopping" />),
+		onSuccess: (_data, _variable, id) => toast.success(<Tran text="server.stop-success" />, { id }),
+		onError: (error, _variable, id) => toast.error(<Tran text="server.stop-fail" />, { error, id }),
+		onSettled: () => revalidate({ path: '/servers' }),
 	});
 
 	return (

--- a/app/[locale]/(main)/servers/create-server-manager.dialog.tsx
+++ b/app/[locale]/(main)/servers/create-server-manager.dialog.tsx
@@ -43,7 +43,7 @@ export default function CreateServerManagerDialog() {
 			form.reset();
 			setOpen(false);
 		},
-		onError: (error) => toast.error(<Tran text="upload.fail" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="upload.fail" />, { error }),
 
 		onSettled: () => {
 			invalidateByKey(['server-managers']);

--- a/app/[locale]/(main)/servers/create-server.dialog.tsx
+++ b/app/[locale]/(main)/servers/create-server.dialog.tsx
@@ -8,6 +8,7 @@ import CreateServerManagerDialog from '@/app/[locale]/(main)/servers/create-serv
 
 import ColorText from '@/components/common/color-text';
 import ComboBox from '@/components/common/combo-box';
+import { PlusIcon } from '@/components/common/icons';
 import Tran from '@/components/common/tran';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
@@ -24,7 +25,6 @@ import { ServerModes } from '@/types/request/UpdateServerRequest';
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { PlusIcon } from '@/components/common/icons';
 
 export default function CreateServerDialog({ defaultOpen }: { defaultOpen?: boolean }) {
 	const [managerId, setManagerId] = useState<string | undefined>('not-selected-yet');
@@ -67,7 +67,7 @@ export default function CreateServerDialog({ defaultOpen }: { defaultOpen?: bool
 
 			router.push(`/servers/${data.id}`);
 		},
-		onError: (error) => toast.error(<Tran text="upload.fail" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="upload.fail" />, { error }),
 
 		onSettled: () => {
 			invalidateByKey(['servers']);

--- a/app/[locale]/(main)/translation/add-key.dialog.tsx
+++ b/app/[locale]/(main)/translation/add-key.dialog.tsx
@@ -39,7 +39,7 @@ export default function AddNewKeyDialog() {
 			form.reset();
 			setOpen(false);
 		},
-		onError: (error) => toast.error(<Tran text="upload.fail" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="upload.fail" />, { error }),
 		onSettled: () => {
 			invalidateByKey(['translations']);
 			clearTranslationCache();

--- a/app/[locale]/(main)/translation/all.table.tsx
+++ b/app/[locale]/(main)/translation/all.table.tsx
@@ -104,7 +104,7 @@ function ValueCard({ tKey: key, keyGroup, value, locale }: ValueCardProps) {
 
 	const { mutate, status } = useMutation({
 		mutationFn: (payload: CreateTranslationRequest) => createTranslation(axios, payload),
-		onError: (error) => toast.error(<Tran text="upload.fail" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="upload.fail" />, { error }),
 		onSuccess: () => clearTranslationCache(),
 	});
 

--- a/app/[locale]/(main)/translation/compare.table.tsx
+++ b/app/[locale]/(main)/translation/compare.table.tsx
@@ -1,13 +1,9 @@
 import dynamic from 'next/dynamic';
 import { Fragment, useState } from 'react';
 
-
-
 import HighLightTranslation from '@/app/[locale]/(main)/translation/highlight-translation';
 import { TranslationCardSkeleton } from '@/app/[locale]/(main)/translation/translation-card.skeleton';
 import TranslationStatus from '@/app/[locale]/(main)/translation/translation-status';
-
-
 
 import CopyButton from '@/components/button/copy.button';
 import GridPaginationList from '@/components/common/grid-pagination-list';
@@ -18,19 +14,19 @@ import { toast } from '@/components/ui/sonner';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Textarea } from '@/components/ui/textarea';
 
-
-
 import useClientApi from '@/hooks/use-client';
 import { Locale } from '@/i18n/config';
-import { CreateTranslationRequest, createTranslation, getTranslationCompare, getTranslationCompareCount } from '@/query/translation';
+import { clearTranslationCache } from '@/lib/utils';
+import {
+	CreateTranslationRequest,
+	createTranslation,
+	getTranslationCompare,
+	getTranslationCompareCount,
+} from '@/query/translation';
 import { TranslationCompare } from '@/types/response/Translation';
 import { TranslationPaginationQuery } from '@/types/schema/search-query';
 
-
-
 import { useMutation } from '@tanstack/react-query';
-import { clearTranslationCache } from '@/lib/utils';
-
 
 const DeleteTranslationDialog = dynamic(() => import('@/app/[locale]/(main)/translation/delete-translation.dialog'));
 
@@ -97,7 +93,7 @@ function CompareCard({ translation, language, target }: CompareCardProps) {
 	const axios = useClientApi();
 	const { mutate, status } = useMutation({
 		mutationFn: (payload: CreateTranslationRequest) => createTranslation(axios, payload),
-		onError: (error) => toast.error(<Tran text="upload.fail" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="upload.fail" />, { error }),
 		onSuccess: () => clearTranslationCache(),
 	});
 

--- a/app/[locale]/(main)/translation/diff-table.tsx
+++ b/app/[locale]/(main)/translation/diff-table.tsx
@@ -14,12 +14,12 @@ import { Textarea } from '@/components/ui/textarea';
 
 import useClientApi from '@/hooks/use-client';
 import { Locale } from '@/i18n/config';
+import { clearTranslationCache } from '@/lib/utils';
 import { CreateTranslationRequest, createTranslation, getTranslationDiff, getTranslationDiffCount } from '@/query/translation';
 import { TranslationDiff } from '@/types/response/Translation';
 import { TranslationPaginationQuery } from '@/types/schema/search-query';
 
 import { useMutation } from '@tanstack/react-query';
-import { clearTranslationCache } from '@/lib/utils';
 
 type DiffTableProps = {
 	language: Locale;
@@ -81,7 +81,7 @@ function DiffCard({ translation, language }: DiffCardProps) {
 	const [isEdit, setEdit] = useState(false);
 	const { mutate, status } = useMutation({
 		mutationFn: (payload: CreateTranslationRequest) => createTranslation(axios, payload),
-		onError: (error) => toast.error(<Tran text="upload.fail" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="upload.fail" />, { error }),
 		onSuccess: () => clearTranslationCache(),
 	});
 

--- a/app/[locale]/(main)/translation/search.table.tsx
+++ b/app/[locale]/(main)/translation/search.table.tsx
@@ -86,7 +86,7 @@ function SearchCard({ translation }: SearchCardProps) {
 	const [isEdit, setEdit] = useState(false);
 	const { mutate, status } = useMutation({
 		mutationFn: (payload: CreateTranslationRequest) => createTranslation(axios, payload),
-		onError: (error) => toast.error(<Tran text="upload.fail" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="upload.fail" />, { error }),
 		onSuccess: () => clearTranslationCache(),
 	});
 

--- a/app/[locale]/(main)/upload/map/page.tsx
+++ b/app/[locale]/(main)/upload/map/page.tsx
@@ -5,6 +5,7 @@ import { useForm } from 'react-hook-form';
 
 import { DetailDescription, DetailTitle } from '@/components/common/detail';
 import { EditClose, EditComponent, EditOff, EditOn, EditTrigger } from '@/components/common/edit-component';
+import ErrorMessage from '@/components/common/error-message';
 import LoadingScreen from '@/components/common/loading-screen';
 import ScrollContainer from '@/components/common/scroll-container';
 import Tran from '@/components/common/tran';
@@ -21,6 +22,7 @@ import UserCard from '@/components/user/user-card';
 import { IMAGE_PREFIX } from '@/constant/constant';
 import { useSession } from '@/context/session.context';
 import useClientApi from '@/hooks/use-client';
+import { isError } from '@/lib/error';
 import { createMap, getMapPreview } from '@/query/map';
 import MapPreviewRequest from '@/types/request/MapPreviewRequest';
 import { MapPreviewResponse } from '@/types/response/MapPreviewResponse';
@@ -29,8 +31,6 @@ import { CreateMapRequest, CreateMapSchema } from '@/types/schema/zod-schema';
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation } from '@tanstack/react-query';
-import ErrorMessage from '@/components/common/error-message';
-import { isError } from '@/lib/error';
 
 /* eslint-disable @next/next/no-img-element */
 
@@ -46,7 +46,7 @@ export default function Page() {
 		},
 		onError: (error) => {
 			setFile(undefined);
-			toast.error(<Tran text="upload.get-preview-fail" />, { description: error?.message });
+			toast.error(<Tran text="upload.get-preview-fail" />, { error });
 		},
 	});
 
@@ -126,7 +126,7 @@ function Upload({ file, preview, setFile, setPreview }: UploadProps) {
 
 			return toast.success(<Tran text="upload.success" />);
 		},
-		onError: (error) => toast.error(<Tran text="upload.fail" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="upload.fail" />, { error }),
 	});
 
 	function handleSubmit(data: any) {

--- a/app/[locale]/(main)/upload/post/page.tsx
+++ b/app/[locale]/(main)/upload/post/page.tsx
@@ -126,7 +126,7 @@ function TranslatePage({
 			setContent({ text: '', files: [] });
 		},
 		onError(error) {
-			toast.error(<Tran text="upload.fail" />, { description: error?.message });
+			toast.error(<Tran text="upload.fail" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['posts']);
@@ -212,7 +212,7 @@ function UploadPage({ shared: { title, setTitle, content, setContent, language, 
 			setSelectedTags([]);
 		},
 		onError(error) {
-			toast.error(<Tran text="upload.fail" />, { description: error?.message });
+			toast.error(<Tran text="upload.fail" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['posts']);

--- a/app/[locale]/(main)/upload/schematic/page.tsx
+++ b/app/[locale]/(main)/upload/schematic/page.tsx
@@ -50,7 +50,7 @@ function Preview() {
 		},
 		onError: (error) => {
 			setData(undefined);
-			toast.error(<Tran text="upload.get-preview-fail" />, { description: error?.message });
+			toast.error(<Tran text="upload.get-preview-fail" />, { error });
 		},
 	});
 
@@ -173,7 +173,7 @@ function Upload({ data, preview, setData, setPreview }: UploadProps) {
 
 			return toast.success(<Tran text="upload.success" />);
 		},
-		onError: (error) => toast.error(<Tran text="upload.fail" />, { description: error?.message }),
+		onError: (error) => toast.error(<Tran text="upload.fail" />, { error }),
 	});
 
 	function handleSubmit(data: any) {

--- a/app/[locale]/(main)/users/[id]/setting/update-thumbnail.tsx
+++ b/app/[locale]/(main)/users/[id]/setting/update-thumbnail.tsx
@@ -45,12 +45,8 @@ export default function UpdateThumbnail({ id }: UpdateThumbnailProps) {
 	const { invalidateByKey } = useQueriesData();
 	const { mutate, isPending } = useMutation({
 		mutationKey: ['update-thumbnail'],
-		mutationFn: async (file: File) =>
-			toast.promise(updateThumbnail(axios, file), {
-				loading: <Tran text="upload.uploading" />,
-				error: (error) => ({ title: <Tran text="upload.fail" />, error }),
-				success: <Tran text="user.update-thumbnail-success" />,
-			}),
+		mutationFn: async (file: File) => updateThumbnail(axios, file),
+		onError: (error) => toast.error(<Tran text="upload.fail" />, { error }),
 		onSuccess: () => {
 			invalidateByKey(['users']);
 			setFile(undefined);

--- a/app/[locale]/(main)/users/[id]/setting/update-thumbnail.tsx
+++ b/app/[locale]/(main)/users/[id]/setting/update-thumbnail.tsx
@@ -15,64 +15,74 @@ import { getUser, updateThumbnail } from '@/query/user';
 import { useMutation, useQuery } from '@tanstack/react-query';
 
 type UpdateThumbnailProps = {
-  id: string;
+	id: string;
 };
 
 export default function UpdateThumbnail({ id }: UpdateThumbnailProps) {
-  const axios = useClientApi();
-  const [file, setFile] = useState<File>();
+	const axios = useClientApi();
+	const [file, setFile] = useState<File>();
 
-  const { data } = useQuery({
-    queryKey: ['users', id],
-    queryFn: () => getUser(axios, { id }),
-  });
+	const { data } = useQuery({
+		queryKey: ['users', id],
+		queryFn: () => getUser(axios, { id }),
+	});
 
-  const imageUrl = useMemo(() => (file ? URL.createObjectURL(file) : data?.thumbnail ? `${data.thumbnail}` : undefined), [file, data?.thumbnail]);
+	const imageUrl = useMemo(
+		() => (file ? URL.createObjectURL(file) : data?.thumbnail ? `${data.thumbnail}` : undefined),
+		[file, data?.thumbnail],
+	);
 
-  function handleFilePick(event: React.ChangeEvent<HTMLInputElement>) {
-    const files = event.currentTarget.files;
+	function handleFilePick(event: React.ChangeEvent<HTMLInputElement>) {
+		const files = event.currentTarget.files;
 
-    if (!files || files.length === 0) {
-      return;
-    }
+		if (!files || files.length === 0) {
+			return;
+		}
 
-    setFile(files[0]);
-  }
+		setFile(files[0]);
+	}
 
-  const { invalidateByKey } = useQueriesData();
-  const { mutate, isPending } = useMutation({
-    mutationKey: ['update-thumbnail'],
-    mutationFn: async (file: File) =>
-      toast.promise(updateThumbnail(axios, file), {
-        loading: <Tran text="upload.uploading" />,
-        error: (error) => ({ title: <Tran text="upload.fail" />, description: error?.message }),
-        success: <Tran text="user.update-thumbnail-success" />,
-      }),
-    onSuccess: () => {
-      invalidateByKey(['users']);
-      setFile(undefined);
-    },
-  });
+	const { invalidateByKey } = useQueriesData();
+	const { mutate, isPending } = useMutation({
+		mutationKey: ['update-thumbnail'],
+		mutationFn: async (file: File) =>
+			toast.promise(updateThumbnail(axios, file), {
+				loading: <Tran text="upload.uploading" />,
+				error: (error) => ({ title: <Tran text="upload.fail" />, error }),
+				success: <Tran text="user.update-thumbnail-success" />,
+			}),
+		onSuccess: () => {
+			invalidateByKey(['users']);
+			setFile(undefined);
+		},
+	});
 
-  return (
-    <div className="flex gap-2 flex-col">
-      <input id="image" className="w-16" hidden accept={acceptedImageFormats} type="file" onChange={handleFilePick} />
-      <label className="flex cursor-pointer items-center justify-center overflow-hidden" htmlFor="image" hidden>
-        {imageUrl && (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img className="object-scale-down border border-border w-full min-h-60 p-2 text-center rounded-lg overflow-hidden" src={imageUrl} alt="preview" />
-        )}
-      </label>
-      {file ? (
-        <Button disabled={isPending} onClick={() => mutate(file)}>
-          <Tran text="user.update-thumbnail" />
-        </Button>
-      ) : (
-        <label className="flex h-fit w-fit cursor-pointer gap-1 border-border justify-center items-center rounded-sm border px-2 py-1" htmlFor="image">
-          <ImageIcon className="size-5" />
-          <Tran text="user.upload-thumbnail" />
-        </label>
-      )}
-    </div>
-  );
+	return (
+		<div className="flex gap-2 flex-col">
+			<input id="image" className="w-16" hidden accept={acceptedImageFormats} type="file" onChange={handleFilePick} />
+			<label className="flex cursor-pointer items-center justify-center overflow-hidden" htmlFor="image" hidden>
+				{imageUrl && (
+					// eslint-disable-next-line @next/next/no-img-element
+					<img
+						className="object-scale-down border border-border w-full min-h-60 p-2 text-center rounded-lg overflow-hidden"
+						src={imageUrl}
+						alt="preview"
+					/>
+				)}
+			</label>
+			{file ? (
+				<Button disabled={isPending} onClick={() => mutate(file)}>
+					<Tran text="user.update-thumbnail" />
+				</Button>
+			) : (
+				<label
+					className="flex h-fit w-fit cursor-pointer gap-1 border-border justify-center items-center rounded-sm border px-2 py-1"
+					htmlFor="image"
+				>
+					<ImageIcon className="size-5" />
+					<Tran text="user.upload-thumbnail" />
+				</label>
+			)}
+		</div>
+	);
 }

--- a/components/common/comment-section.tsx
+++ b/components/common/comment-section.tsx
@@ -202,7 +202,7 @@ function CommentInput({ itemId }: CommentInputProps) {
 			invalidateByKey([`comments-${itemId}`]);
 		},
 		onError: (error) => {
-			toast.error(<Tran text="error" />, { description: error?.message });
+			toast.error(<Tran text="error" />, { error });
 		},
 		onSettled: () => {
 			filterByKey<Comment>([`comments-${itemId}`], (comment) => !isNumeric(comment.id));

--- a/components/document/document-card.tsx
+++ b/components/document/document-card.tsx
@@ -25,7 +25,7 @@ export default function DocumentCard({ document: { id, text, metadata } }: Props
 			toast.success(<Tran text="delete-success" />);
 		},
 		onError: (error) => {
-			toast.error(<Tran text="delete-fail" />, { description: error?.message });
+			toast.error(<Tran text="delete-fail" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['documents']);

--- a/components/map/delete-map.button.tsx
+++ b/components/map/delete-map.button.tsx
@@ -33,7 +33,7 @@ export function DeleteMapButton({ id, name, variant }: DeleteMapButtonProps) {
 			toast.success(<Tran text="delete-success" />);
 		},
 		onError: (error) => {
-			toast.error(<Tran text="delete-fail" />, { description: error?.message });
+			toast.error(<Tran text="delete-fail" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['maps']);

--- a/components/map/take-down-map.button.tsx
+++ b/components/map/take-down-map.button.tsx
@@ -32,7 +32,7 @@ export function TakeDownMapButton({ id, name }: TakeDownMapButtonProps) {
 			toast(<Tran text="take-down-success" />);
 		},
 		onError: (error) => {
-			toast(<Tran text="take-down-fail" />, { description: error?.message });
+			toast.error(<Tran text="take-down-fail" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['maps']);

--- a/components/map/verify-map.button.tsx
+++ b/components/map/verify-map.button.tsx
@@ -28,7 +28,6 @@ export default function VerifyMapButton({ id, name, selectedTags }: VerifyMapBut
 		mutationFn: (data: VerifyMapRequest) => verifyMap(axios, data),
 		onSuccess: () => {
 			back();
-			toast(<Tran text="verify-success" />);
 		},
 		onError: (error) => {
 			toast(<Tran text="verify-fail" />, {

--- a/components/map/verify-map.button.tsx
+++ b/components/map/verify-map.button.tsx
@@ -31,7 +31,7 @@ export default function VerifyMapButton({ id, name, selectedTags }: VerifyMapBut
 		},
 		onError: (error) => {
 			toast(<Tran text="verify-fail" />, {
-				description: error?.message,
+				error,
 			});
 		},
 		onSettled: () => {

--- a/components/plugin/plugin-card.tsx
+++ b/components/plugin/plugin-card.tsx
@@ -37,7 +37,7 @@ export default function PluginCard({ plugin: { id, name, description, url, userI
 			toast.success(<Tran text="delete-success" />);
 		},
 		onError: (error) => {
-			toast.error(<Tran text="delete-fail" />, { description: error?.message });
+			toast.error(<Tran text="delete-fail" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['plugins']);
@@ -49,7 +49,7 @@ export default function PluginCard({ plugin: { id, name, description, url, userI
 			toast.success(<Tran text="delete-success" />);
 		},
 		onError: (error) => {
-			toast.error(<Tran text="delete-fail" />, { description: error?.message });
+			toast.error(<Tran text="delete-fail" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['plugins']);

--- a/components/plugin/upload-plugin-preview-card.tsx
+++ b/components/plugin/upload-plugin-preview-card.tsx
@@ -44,7 +44,7 @@ function UploadPluginCard({ plugin }: Props) {
 			toast.success(<Tran text="delete-success" />);
 		},
 		onError: (error) => {
-			toast.error(<Tran text="delete-fail" />, { description: error?.message });
+			toast.error(<Tran text="delete-fail" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['plugins']);
@@ -99,7 +99,7 @@ function VerifyPluginDialog({ plugin: { id, tags } }: DialogProps) {
 	const { mutate, isPending } = useMutation({
 		mutationFn: (data: VerifyPluginRequest) => verifyPlugin(axios, data),
 		onError: (error) => {
-			toast(<Tran text="verify-fail" />, { description: error?.message });
+			toast.error(<Tran text="verify-fail" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['plugins']);

--- a/components/plugin/upload-plugin-preview-card.tsx
+++ b/components/plugin/upload-plugin-preview-card.tsx
@@ -98,9 +98,6 @@ function VerifyPluginDialog({ plugin: { id, tags } }: DialogProps) {
 
 	const { mutate, isPending } = useMutation({
 		mutationFn: (data: VerifyPluginRequest) => verifyPlugin(axios, data),
-		onSuccess: () => {
-			toast(<Tran text="verify-success" />);
-		},
 		onError: (error) => {
 			toast(<Tran text="verify-fail" />, { description: error?.message });
 		},

--- a/components/post/post-detail-card.tsx
+++ b/components/post/post-detail-card.tsx
@@ -44,7 +44,7 @@ export default function PostDetailCard({
 			toast(<Tran text="take-down-success" />);
 		},
 		onError: (error) => {
-			toast(<Tran text="take-down-fail" />, { description: error?.message });
+			toast.error(<Tran text="take-down-fail" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['posts']);
@@ -58,7 +58,7 @@ export default function PostDetailCard({
 			toast.success(<Tran text="delete-success" />);
 		},
 		onError: (error) => {
-			toast.error(<Tran text="delete-fail" />, { description: error?.message });
+			toast.error(<Tran text="delete-fail" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['posts']);

--- a/components/post/upload-post-detail-card.tsx
+++ b/components/post/upload-post-detail-card.tsx
@@ -39,12 +39,13 @@ export default function UploadPostDetailCard({ post }: UploadPostDetailCardProps
 	const { mutate: verifyPostById, isPending: isVerifying } = useMutation({
 		mutationFn: (data: VerifyPostRequest) => verifyPost(axios, data),
 		onSuccess: () => {
-			invalidateByKey(['posts']);
 			back();
-			toast(<Tran text="verify-success" />);
 		},
 		onError: (error) => {
 			toast(<Tran text="verify-fail" />, { description: error?.message });
+		},
+		onSettled: () => {
+			invalidateByKey(['posts']);
 		},
 	});
 

--- a/components/post/upload-post-detail-card.tsx
+++ b/components/post/upload-post-detail-card.tsx
@@ -42,7 +42,7 @@ export default function UploadPostDetailCard({ post }: UploadPostDetailCardProps
 			back();
 		},
 		onError: (error) => {
-			toast(<Tran text="verify-fail" />, { description: error?.message });
+			toast.error(<Tran text="verify-fail" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['posts']);
@@ -56,7 +56,7 @@ export default function UploadPostDetailCard({ post }: UploadPostDetailCardProps
 			toast.success(<Tran text="delete-success" />);
 		},
 		onError: (error) => {
-			toast.error(<Tran text="delete-fail" />, { description: error?.message });
+			toast.error(<Tran text="delete-fail" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['posts']);

--- a/components/schematic/delete-schematic.button.tsx
+++ b/components/schematic/delete-schematic.button.tsx
@@ -34,7 +34,7 @@ export default function DeleteSchematicButton({ id, name, variant }: DeleteSchem
 			back();
 		},
 		onError: (error) => {
-			toast.error(<Tran text="delete-fail" />, { description: error?.message });
+			toast.error(<Tran text="delete-fail" />, { error });
 		},
 	});
 

--- a/components/schematic/take-down-schematic.button.tsx
+++ b/components/schematic/take-down-schematic.button.tsx
@@ -32,7 +32,7 @@ export default function TakeDownSchematicButton({ id, name }: TakeDownSchematicB
 			toast(<Tran text="take-down-success" />);
 		},
 		onError: (error) => {
-			toast(<Tran text="take-down-fail" />, { description: error?.message });
+			toast.error(<Tran text="take-down-fail" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['schematics']);

--- a/components/schematic/verify-schematic.button.tsx
+++ b/components/schematic/verify-schematic.button.tsx
@@ -30,7 +30,7 @@ export default function VerifySchematicButton({ id, name, selectedTags }: Verify
 			back();
 		},
 		onError: (error) => {
-			toast.error(<Tran text="verify-fail" />, { description: error?.message });
+			toast.error(<Tran text="verify-fail" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['schematics']);

--- a/components/schematic/verify-schematic.button.tsx
+++ b/components/schematic/verify-schematic.button.tsx
@@ -27,12 +27,13 @@ export default function VerifySchematicButton({ id, name, selectedTags }: Verify
 	const { mutate, isPending } = useMutation({
 		mutationFn: (data: VerifySchematicRequest) => verifySchematic(axios, data),
 		onSuccess: () => {
-			invalidateByKey(['schematics']);
-			toast.success(<Tran text="verify-success" />);
 			back();
 		},
 		onError: (error) => {
 			toast.error(<Tran text="verify-fail" />, { description: error?.message });
+		},
+		onSettled: () => {
+			invalidateByKey(['schematics']);
 		},
 	});
 

--- a/components/server/server-map-card.tsx
+++ b/components/server/server-map-card.tsx
@@ -31,7 +31,7 @@ export default function ServerMapCard({ map: { name, mapId, serverId } }: Server
 			toast(<Tran text="delete-success" />);
 		},
 		onError: (error) => {
-			toast.error(<Tran text="delete-fail" />, { description: error?.message });
+			toast.error(<Tran text="delete-fail" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['servers', serverId, 'maps']);

--- a/components/server/server-plugin-card.tsx
+++ b/components/server/server-plugin-card.tsx
@@ -28,7 +28,7 @@ export default function ServerPluginCard({ plugin: { serverId, pluginId, name, d
 			toast.success(<Tran text="delete-success" />);
 		},
 		onError: (error) => {
-			toast.error(<Tran text="delete-fail" />, { description: error?.message });
+			toast.error(<Tran text="delete-fail" />, { error });
 		},
 		onSettled: () => {
 			invalidateByKey(['servers', serverId, 'plugins']);

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -8,6 +8,7 @@ import { AlertTriangleIcon, CheckCircleIcon, XCircleIcon, XIcon } from '@/compon
 import LoadingSpinner from '@/components/common/loading-spinner';
 import Tran from '@/components/common/tran';
 
+import { getErrorMessage, TError } from '@/lib/error';
 import { cn, hasProperty } from '@/lib/utils';
 
 type ToasterProps = React.ComponentProps<typeof Sonner>;
@@ -70,7 +71,22 @@ toast.success = (title: ReactNode, options?: ToastOptions) => {
 	});
 };
 
-toast.error = (title: ReactNode, options?: ToastOptions) => {
+toast.error = (
+	title: ReactNode,
+	options?: ToastOptions & {
+		error?: TError;
+	},
+) => {
+	
+	if (options?.error) {
+		return toast(title, {
+			icon: <XCircleIcon className="size-4" />,
+			className: 'text-destructive-foreground bg-destructive border-destructive',
+			...options,
+			description: getErrorMessage(options.error),
+		});
+	}
+
 	return toast(title, {
 		icon: <XCircleIcon className="size-4" />,
 		className: 'text-destructive-foreground bg-destructive border-destructive',

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -6,8 +6,9 @@ import { Toaster as Sonner, toast as defaultToast } from 'sonner';
 
 import { AlertTriangleIcon, CheckCircleIcon, XCircleIcon, XIcon } from '@/components/common/icons';
 import LoadingSpinner from '@/components/common/loading-spinner';
+import Tran from '@/components/common/tran';
 
-import { cn } from '@/lib/utils';
+import { cn, hasProperty } from '@/lib/utils';
 
 type ToasterProps = React.ComponentProps<typeof Sonner>;
 
@@ -73,6 +74,38 @@ toast.error = (title: ReactNode, options?: ToastOptions) => {
 	return toast(title, {
 		icon: <XCircleIcon className="size-4" />,
 		className: 'text-destructive-foreground bg-destructive border-destructive',
+		...options,
+	});
+};
+
+const httpStatusMessage: {
+	[status: number]: string;
+} = {
+	400: 'bad-request',
+	401: 'unauthorized',
+	403: 'forbidden',
+	404: 'not-found',
+	409: 'conflict',
+	422: 'unprocessable-entity',
+	429: 'too-many-requests',
+	500: 'internal-server-error',
+	502: 'bad-gateway',
+};
+
+toast.httpError = (error: any, options?: Omit<ToastOptions, 'description'>) => {
+	if (hasProperty(error, 'response') && hasProperty(error.response, 'status')) {
+		const status = error.response.status as number;
+		const message = error.response.data.message;
+
+		const statusMessage = httpStatusMessage[status] ?? 'unknown';
+
+		return toast.error(<Tran text={statusMessage} />, {
+			description: message,
+		});
+	}
+
+	return toast.error(<Tran text="error" />, {
+		description: JSON.stringify(error),
 		...options,
 	});
 };

--- a/hooks/use-clipboard.tsx
+++ b/hooks/use-clipboard.tsx
@@ -4,25 +4,25 @@ import Tran from '@/components/common/tran';
 import { toast } from '@/components/ui/sonner';
 
 type CopyProps = {
-  data: string;
-  title?: ReactNode;
-  content?: ReactNode;
+	data: string;
+	title?: ReactNode;
+	content?: ReactNode;
 };
 
 let dismissLast: (() => void) | null = null;
 
 export default function useClipboard() {
-  return useCallback(async ({ data, title = <Tran text="copied" />, content = '' }: CopyProps) => {
-    if (dismissLast) {
-      dismissLast();
-    }
+	return useCallback(async ({ data, title = <Tran text="copied" />, content = '' }: CopyProps) => {
+		if (dismissLast) {
+			dismissLast();
+		}
 
-    const id = await toast.promise(navigator.clipboard.writeText(data), {
-      success: () => ({ title, description: content }),
-    });
+		const id = await toast.promise(navigator.clipboard.writeText(data), {
+			success: () => ({ title, description: content }),
+		});
 
-    dismissLast = () => toast.dismiss(id);
+		dismissLast = () => toast.dismiss(id);
 
-    return () => toast.dismiss(id);
-  }, []);
+		return () => toast.dismiss(id);
+	}, []);
 }

--- a/hooks/use-mindustry-gpt.tsx
+++ b/hooks/use-mindustry-gpt.tsx
@@ -109,7 +109,7 @@ export default function useMindustryGpt({ url }: MindustryGptConfig) {
 			setAbortController(null);
 		},
 		onError: (error) => {
-			toast.error(<Tran text="error" />, { description: error?.message });
+			toast.error(<Tran text="error" />, { error });
 		},
 	});
 

--- a/lib/error.ts
+++ b/lib/error.ts
@@ -39,7 +39,7 @@ export function getErrorMessage(error: TError) {
 		return error;
 	}
 
-	if ('response' in error) {
+	if (typeof error === 'object' && 'response' in error) {
 		if (error.response?.data?.message) {
 			return error.response?.data?.message;
 		}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -372,3 +372,4 @@ export function generateAlternate(path: string) {
 export function hasProperty(obj: any, key: string): obj is { [key: string]: any} {
 	return typeof obj === 'object' && obj !== null && key in obj;
 }
+

--- a/query/config/config.tsx
+++ b/query/config/config.tsx
@@ -1,10 +1,9 @@
 import Axios from 'axios';
 
-import Tran from '@/components/common/tran';
 import { toast } from '@/components/ui/sonner';
 
 import env from '@/constant/env';
-import { hasProperty, uuid } from '@/lib/utils';
+import { uuid } from '@/lib/utils';
 
 function logError(error: unknown) {
 	try {
@@ -42,25 +41,6 @@ axiosInstance.interceptors.response.use(
 		if (typeof window !== 'undefined') {
 			if (typeof error === 'string') {
 				toast.error(error);
-			} else if (hasProperty(error, 'response') && hasProperty(error.response, 'status')) {
-				const status = error.response.status;
-				const message = error.response.data.message;
-
-				if (status === 400) {
-					toast.error(<Tran text="bad-request" />, {
-						description: message,
-					});
-				} else if (status === 401) {
-					toast.error(<Tran text="unauthorized" />);
-				} else if (status === 403) {
-					toast.error(<Tran text="forbidden" />);
-				} else if (status === 404) {
-					toast.error(<Tran text="not-found" />);
-				} else if (status === 409) {
-					toast.error(<Tran text="conflict" />);
-				} else if (status === 500) {
-					toast.error(<Tran text="internal-server-error" />);
-				}
 			}
 		}
 
@@ -73,13 +53,11 @@ axiosInstance.interceptors.response.use(
 	},
 );
 
-
 axiosInstance.interceptors.request.use((config) => {
 	if (process.env.NODE_ENV !== 'production') {
 		const id = uuid();
-		config.headers['x-request-id'] = uuid()
+		config.headers['x-request-id'] = uuid();
 		console.time(`${id} ${config.method?.toUpperCase()} ${config.url}`);
-
 	}
 
 	return config;


### PR DESCRIPTION
This commit centralizes HTTP error handling logic in the sonner component by introducing a new `toast.httpError` method. It also removes redundant success toast notifications from various verification components and moves cache invalidation to the `onSettled` callback for consistency.