### PR TITLE
refactor(usage-card): remove Skeleton component and return null durin…

### DIFF
--- a/app/[locale]/(main)/servers/[id]/(dashboard)/usage-card.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/usage-card.tsx
@@ -3,7 +3,6 @@
 import dynamic from 'next/dynamic';
 
 import Tran from '@/components/common/tran';
-import { Skeleton } from '@/components/ui/skeleton';
 
 import useServerStats from '@/hooks/useServerStats';
 
@@ -17,7 +16,7 @@ export default function UsageCard({ id }: UsageCardProps) {
 	const { data, isLoading } = useServerStats(id);
 
 	if (isLoading || !data) {
-		return <Skeleton className="flex h-full w-full" />;
+		return null;
 	}
 
 	const { cpuUsage, ramUsage, totalRam } = data;


### PR DESCRIPTION
…g loading

The Skeleton component was removed to simplify the loading state handling in the UsageCard component. Returning null during loading is more straightforward and avoids unnecessary rendering of a placeholder element.