### PR TITLE
refactor(socket): separate cleanup effect in SocketProvider

### DIFF
--- a/context/socket.context.tsx
+++ b/context/socket.context.tsx
@@ -61,11 +61,13 @@ export function SocketProvider({ children }: { children: ReactNode }) {
 		socket.onError(() => {
 			setState(socket.getState());
 		});
+	}, [socket, authState]);
 
+	useEffect(() => {
 		return () => {
 			socket.close();
 		};
-	}, [socket, authState]);
+	}, [socket]);
 
 	return (
 		<SocketContext.Provider


### PR DESCRIPTION
Separate the socket cleanup logic into its own useEffect to improve code clarity and maintainability. This ensures the cleanup only depends on the socket and not on authState, reducing unnecessary re-renders.