### PR TITLE
feat(server-plugin-card): display filename in plugin card

### DIFF
--- a/components/server/server-plugin-card.tsx
+++ b/components/server/server-plugin-card.tsx
@@ -61,6 +61,7 @@ export default function ServerPluginCard({ serverId, plugin: { name, filename, m
 				<span className="text-base font-semibold">({version.startsWith('v') ? version : 'v' + version})</span>
 			</h2>
 			<span>{author}</span>
+			<span className="overflow-hidden text-ellipsis text-left text-secondary-foreground">{filename}</span>
 			<Popover>
 				<PopoverTrigger>
 					<p className="line-clamp-3 overflow-hidden text-ellipsis text-left text-secondary-foreground">


### PR DESCRIPTION
Add the filename to the server plugin card to provide more context about the plugin being displayed. This helps users quickly identify the specific plugin file associated with the card.