### PR TITLE
refactor(posts): remove initial data props and simplify page logic

### DIFF
--- a/app/[locale]/(main)/posts/page.client.tsx
+++ b/app/[locale]/(main)/posts/page.client.tsx
@@ -12,14 +12,9 @@ import NameTagSearch from '@/components/search/name-tag-search';
 
 import env from '@/constant/env';
 import { getPostCount, getPosts } from '@/query/post';
-import { Post } from '@/types/response/Post';
 import { ItemPaginationQuery } from '@/types/schema/search-query';
 
-type Props = {
-	posts: Post[];
-};
-
-export default function Client({ posts }: Props) {
+export default function Client() {
 	const uploadLink = `${env.url.base}/upload/post`;
 
 	return (
@@ -31,7 +26,6 @@ export default function Client({ posts }: Props) {
 					paramSchema={ItemPaginationQuery}
 					queryKey={['posts']}
 					queryFn={getPosts}
-					initialData={posts}
 				>
 					{(page) => page.map((data) => <PostPreviewCard key={data.id} post={data} />)}
 				</InfinitePage>

--- a/app/[locale]/(main)/posts/page.tsx
+++ b/app/[locale]/(main)/posts/page.tsx
@@ -2,15 +2,10 @@ import { Metadata } from 'next';
 
 import Client from '@/app/[locale]/(main)/posts/page.client';
 
-import ErrorScreen from '@/components/common/error-screen';
-
-import { serverApi } from '@/action/common';
 import { Locale } from '@/i18n/config';
 import { getTranslation } from '@/i18n/server';
-import { isError } from '@/lib/error';
 import { formatTitle, generateAlternate } from '@/lib/utils';
-import { getPosts } from '@/query/post';
-import { ItemPaginationQuery, ItemPaginationQueryType } from '@/types/schema/search-query';
+import { ItemPaginationQueryType } from '@/types/schema/search-query';
 
 type Props = {
 	searchParams: Promise<ItemPaginationQueryType>;
@@ -33,18 +28,6 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 	};
 }
 
-export default async function Page({ searchParams }: Props) {
-	const { data, success, error } = ItemPaginationQuery.safeParse(await searchParams);
-
-	if (!success || !data) {
-		return <ErrorScreen error={error} />;
-	}
-
-	const posts = await serverApi((axios) => getPosts(axios, data));
-
-	if (isError(posts)) {
-		return <ErrorScreen error={posts} />;
-	}
-
-	return <Client posts={posts} />;
+export default async function Page() {
+	return <Client />;
 }

--- a/app/[locale]/(main)/upload/post/page.tsx
+++ b/app/[locale]/(main)/upload/post/page.tsx
@@ -15,6 +15,7 @@ import { SearchBar, SearchInput } from '@/components/search/search-input';
 import TagSelector from '@/components/search/tag-selector';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import Divider from '@/components/ui/divider';
 import { Input } from '@/components/ui/input';
 import { toast } from '@/components/ui/sonner';
 
@@ -62,9 +63,13 @@ export default function Page() {
 		if (post === undefined) {
 			return (
 				<Fragment>
-					<div className="rounded-md">
+					<div className="flex justify-between gap-2 items-center">
+						<h2>
+							<Tran text="post.upload" />
+						</h2>
 						<AddTranslationDialog onPostSelect={handlePostSelect} />
 					</div>
+					<Divider />
 					<UploadPage
 						shared={{
 							title,
@@ -82,10 +87,18 @@ export default function Page() {
 		return (
 			<Fragment>
 				<div className="space-x-2 rounded-sm">
-					<Button title="Upload" variant="secondary" onClick={() => setPost(undefined)}>
-						<Tran text="upload.go-to-upload-page" />
-					</Button>
-					<AddTranslationDialog onPostSelect={handlePostSelect} />
+					<div className="flex justify-between gap-2 items-center">
+						<h2>
+							<Tran text="post.translate" />
+						</h2>
+						<div className="flex justify-between gap-2 items-center">
+							<Button title="Upload" variant="secondary" onClick={() => setPost(undefined)}>
+								<Tran text="upload.go-to-upload-page" />
+							</Button>
+							<AddTranslationDialog onPostSelect={handlePostSelect} />
+						</div>
+					</div>
+					<Divider />
 				</div>
 				<TranslatePage
 					post={post}
@@ -156,15 +169,26 @@ function TranslatePage({
 		<div className="flex h-full overflow-hidden rounded-md">
 			<div className="hidden h-full w-full flex-col justify-between gap-2 overflow-hidden md:flex">
 				<div className="flex h-full flex-col gap-2 overflow-hidden rounded-md">
-					<Input
-						className="w-full rounded-sm outline-none hover:outline-none"
-						placeholder="Title"
-						value={title}
-						onChange={(event) => setTitle(event.currentTarget.value)}
-					/>
-					<MarkdownEditor value={content} onChange={(value) => setContent(value(content))} />
+					<div className="space-y-1">
+						<h4>
+							<Tran text="upload.post-title" asChild />
+						</h4>
+						<Input
+							className="w-full rounded-sm outline-none hover:outline-none"
+							placeholder="Title"
+							value={title}
+							onChange={(event) => setTitle(event.currentTarget.value)}
+						/>
+					</div>
+					<div className="space-y-1 h-full flex flex-col">
+						<h4>
+							<Tran text="upload.post-content" asChild />
+						</h4>
+						<MarkdownEditor value={content} onChange={(value) => setContent(value(content))} />
+					</div>
 				</div>
-				<div className="flex items-center justify-start gap-2 rounded-md ">
+				<Divider />
+				<div className="flex items-center justify-start gap-2">
 					<ComboBox
 						placeholder={t('select-language')}
 						value={{ label: t(language || 'en'), value: language }}
@@ -237,15 +261,26 @@ function UploadPage({ shared: { title, setTitle, content, setContent, language, 
 		<div className="flex h-full flex-col overflow-hidden rounded-md">
 			<div className="flex h-full w-full flex-col gap-2 overflow-hidden">
 				<div className="flex h-full flex-col gap-2 overflow-hidden rounded-md">
-					<Input
-						className="w-full rounded-sm  outline-none hover:outline-none"
-						placeholder={t('title')}
-						value={title}
-						onChange={(event) => setTitle(event.currentTarget.value)}
-					/>
-					<MarkdownEditor value={content} onChange={(value) => setContent(value(content))} />
+					<div className="space-y-1">
+						<h4>
+							<Tran text="upload.post-title" asChild />
+						</h4>
+						<Input
+							className="w-full rounded-sm  outline-none hover:outline-none"
+							placeholder={t('title')}
+							value={title}
+							onChange={(event) => setTitle(event.currentTarget.value)}
+						/>
+					</div>
+					<div className="space-y-1 h-full flex flex-col">
+						<h4>
+							<Tran text="upload.post-content" asChild />
+						</h4>
+						<MarkdownEditor value={content} onChange={(value) => setContent(value(content))} />
+					</div>
 				</div>
-				<div className="flex items-center justify-start gap-2 overflow-hidden rounded-md ">
+				<Divider />
+				<div className="flex items-center justify-start gap-2">
 					<ComboBox
 						placeholder={t('select-language')}
 						value={{ label: t(language || 'en'), value: language }}


### PR DESCRIPTION
Refactor the posts page to remove the initial data props and simplify the logic by relying on the `InfinitePage` component to fetch data directly. This improves maintainability and reduces unnecessary data passing between components. Additionally, update the upload post page to improve UI consistency by adding headers and dividers.