### PR TITLE
fix: correct plugin filename parsing by removing extra character

### DIFF
--- a/app/[locale]/(main)/servers/[id]/layout.tsx
+++ b/app/[locale]/(main)/servers/[id]/layout.tsx
@@ -41,7 +41,7 @@ function PluginLabel() {
 	const axios = useClientApi();
 
 	const shouldCheckPlugins = data
-		?.map((p) => p.filename.replace('.jar', '').split('_)'))
+		?.map((p) => p.filename.replace('.jar', '').split('_'))
 		.filter((p) => p.length === 2)
 		.map((p) => p[1])
 		.filter((p) => !!p);


### PR DESCRIPTION
The previous code incorrectly split plugin filenames using '_)' as the delimiter, which caused parsing issues. This commit fixes the delimiter to '_' to ensure proper parsing of plugin filenames.