### PR TITLE
refactor(servers): improve plugin label data structure

### DIFF
--- a/app/[locale]/(main)/servers/[id]/layout.tsx
+++ b/app/[locale]/(main)/servers/[id]/layout.tsx
@@ -43,8 +43,11 @@ function PluginLabel() {
 	const shouldCheckPlugins = data
 		?.map((p) => p.filename.replace('.jar', '').split('_'))
 		.filter((p) => p.length === 2)
-		.map((p) => p[1])
-		.filter((p) => !!p);
+		.filter((p) => !!p[1])
+		.map((p) => ({
+			id: p[0],
+			version: p[1],
+		}));
 
 	const { data: version } = useQuery({
 		queryKey: ['server', id, 'plugin-version'],


### PR DESCRIPTION
Refactor the plugin label data mapping to include both id and version as an object. This enhances readability and prepares for future extensions where both fields might be needed.