### PR TITLE
fix: invalidate plugin-version cache after plugin operations

### DIFF
--- a/app/[locale]/(main)/servers/[id]/plugins/download-plugin-list.tsx
+++ b/app/[locale]/(main)/servers/[id]/plugins/download-plugin-list.tsx
@@ -108,6 +108,7 @@ function AddServerPluginCard({ plugin }: AddServerPluginCardProps) {
 		},
 		onSettled: () => {
 			invalidateByKey(['server', id, 'plugin']);
+			invalidateByKey(['server', id, 'plugin-version']);
 		},
 	});
 

--- a/components/server/server-plugin-card.tsx
+++ b/components/server/server-plugin-card.tsx
@@ -52,6 +52,7 @@ export default function ServerPluginCard({ serverId, plugin: { name, filename, m
 		},
 		onSettled: () => {
 			invalidateByKey(['servers', serverId, 'plugins']);
+			invalidateByKey(['server', serverId, 'plugin-version']);
 		},
 	});
 


### PR DESCRIPTION
Ensure the plugin-version cache is invalidated after plugin-related operations to maintain data consistency and avoid stale data.