### PR TITLE
fix(servers): include data in plugin version query key

### DIFF
--- a/app/[locale]/(main)/servers/[id]/layout.tsx
+++ b/app/[locale]/(main)/servers/[id]/layout.tsx
@@ -51,7 +51,7 @@ function PluginLabel() {
 		}));
 
 	const { data: version } = useQuery({
-		queryKey: ['server', id, 'plugin-version'],
+		queryKey: ['server', id, 'plugin-version', data],
 		queryFn: () =>
 			axios
 				.post('plugins/check-version', shouldCheckPlugins, { withCredentials: true })

--- a/app/[locale]/(main)/servers/[id]/plugins/download-plugin-list.tsx
+++ b/app/[locale]/(main)/servers/[id]/plugins/download-plugin-list.tsx
@@ -125,7 +125,7 @@ function AddServerPluginCard({ plugin }: AddServerPluginCardProps) {
 					'opacity-50': state === 'up-to-date',
 				},
 			)}
-			disabled={isPending || state === 'up-to-date'}
+			disabled={isPending}
 			onClick={() => mutate(plugin.id)}
 			layout
 		>

--- a/app/[locale]/(main)/servers/[id]/plugins/download-plugin-list.tsx
+++ b/app/[locale]/(main)/servers/[id]/plugins/download-plugin-list.tsx
@@ -119,7 +119,7 @@ function AddServerPluginCard({ plugin }: AddServerPluginCardProps) {
 	return (
 		<motion.button
 			className={cn(
-				'relative border flex h-40 min-h-40 w-full flex-col items-start justify-start gap-2 overflow-hidden rounded-md bg-card p-4 text-start  cursor-pointer',
+				'relative border flex h-40 min-h-40 w-full flex-col items-start justify-start gap-2 overflow-hidden rounded-md bg-card p-4 text-start',
 				{
 					'hover:border-brand': state !== 'up-to-date',
 					'opacity-50': state === 'up-to-date',

--- a/components/server/server-plugin-card.tsx
+++ b/components/server/server-plugin-card.tsx
@@ -128,7 +128,11 @@ function PluginVersion({ id: pluginId, version, filename }: { id: string; versio
 						{isPending ? (
 							<LoadingSpinner />
 						) : (
-							<button className="flex items-center gap-2" onClick={() => mutate(pluginId)} disabled={isPending}>
+							<button
+								className="flex items-center gap-1 border p-2 rounded-md w-fit bg-secondary"
+								onClick={() => mutate(pluginId)}
+								disabled={isPending}
+							>
 								<span className="text-destructive-foreground">{dateToId(new Date(Number(version)))}</span>
 								<span>{'=>'}</span>
 								<span className="text-success-foreground">{dateToId(new Date(data.version))}</span>


### PR DESCRIPTION
The query key for the plugin version was missing the `data` dependency, which could lead to stale or incorrect cache results. Adding `data` ensures the query is correctly invalidated when the data changes.