### PR TITLE
refactor: wrap UUID and IP visibility text in span tags

### DIFF
--- a/app/[locale]/(main)/servers/[id]/logs/server-build-log-card.tsx
+++ b/app/[locale]/(main)/servers/[id]/logs/server-build-log-card.tsx
@@ -43,8 +43,12 @@ export default function ServerBuildLogCard({ serverId, data: { player, events },
 					<div className="flex gap-2">
 						<span className="font-semibold">UUID:</span>
 						<Visibility>
-							<VisibilityOn>{uuid}</VisibilityOn>
-							<VisibilityOff>{'*'.repeat(27)}</VisibilityOff>
+							<VisibilityOn>
+								<span>{uuid}</span>
+							</VisibilityOn>
+							<VisibilityOff>
+								<span>{'*'.repeat(27)}</span>
+							</VisibilityOff>
 						</Visibility>
 					</div>
 				</div>

--- a/app/[locale]/(main)/servers/[id]/logs/server-login-log-card.tsx
+++ b/app/[locale]/(main)/servers/[id]/logs/server-login-log-card.tsx
@@ -27,15 +27,23 @@ export default function ServerLoginLogCard({ serverId, data: { name, uuid, ip, c
 				<div className="flex items-center gap-2 group">
 					<span className="font-semibold">UUID: </span>
 					<Visibility>
-						<VisibilityOff>{'*'.repeat(27)}</VisibilityOff>
-						<VisibilityOn>{uuid}</VisibilityOn>
+						<VisibilityOff>
+							<span>{'*'.repeat(27)}</span>
+						</VisibilityOff>
+						<VisibilityOn>
+							<span>{uuid}</span>
+						</VisibilityOn>
 					</Visibility>
 				</div>
 				<div className="flex items-center gap-2 group">
 					<span className="font-semibold">IP: </span>
 					<Visibility>
-						<VisibilityOff>{ip.replaceAll(/\d/g, '*')}</VisibilityOff>
-						<VisibilityOn>{ip}</VisibilityOn>
+						<VisibilityOff>
+							<span>{ip.replaceAll(/\d/g, '*')}</span>
+						</VisibilityOff>
+						<VisibilityOn>
+							<span>{ip}</span>
+						</VisibilityOn>
 					</Visibility>
 				</div>
 				<RelativeTime date={new Date(createdAt)} />

--- a/app/[locale]/(main)/servers/[id]/players/page.client.tsx
+++ b/app/[locale]/(main)/servers/[id]/players/page.client.tsx
@@ -94,8 +94,12 @@ function PlayerInfoCard({ serverId, info }: PlayerInfoCardProps) {
 					<div className="text-sm text-muted-foreground">
 						ID:
 						<Visibility>
-							<VisibilityOff>{id.replace(/./g, '*')}</VisibilityOff>
-							<VisibilityOn>{id}</VisibilityOn>
+							<VisibilityOff>
+								<span>{id.replace(/./g, '*')}</span>
+							</VisibilityOff>
+							<VisibilityOn>
+								<span>{id}</span>
+							</VisibilityOn>
 						</Visibility>
 					</div>
 				</div>
@@ -110,8 +114,12 @@ function PlayerInfoCard({ serverId, info }: PlayerInfoCardProps) {
 					<div className="text-muted-foreground">Last IP</div>
 					<div className="font-mono">
 						<Visibility>
-							<VisibilityOff>{lastIP.replace(/\d/g, '*')}</VisibilityOff>
-							<VisibilityOn>{lastIP}</VisibilityOn>
+							<VisibilityOff>
+								<span>{lastIP.replace(/\d/g, '*')}</span>
+							</VisibilityOff>
+							<VisibilityOn>
+								<span>{lastIP}</span>
+							</VisibilityOn>
 						</Visibility>
 					</div>
 				</div>
@@ -119,8 +127,12 @@ function PlayerInfoCard({ serverId, info }: PlayerInfoCardProps) {
 					<div className="text-muted-foreground">IPs</div>
 					<div className="font-mono">
 						<Visibility>
-							<VisibilityOff>{ips.map((ip) => ip.replace(/\d/g, '*')).join(', ')}</VisibilityOff>
-							<VisibilityOn>{ips.join(', ')}</VisibilityOn>
+							<VisibilityOff>
+								<span>{ips.map((ip) => ip.replace(/\d/g, '*')).join(', ')}</span>
+							</VisibilityOff>
+							<VisibilityOn>
+								<span>{ips.join(', ')}</span>
+							</VisibilityOn>
 						</Visibility>
 					</div>
 				</div>


### PR DESCRIPTION
Improve consistency and maintainability by wrapping all UUID and IP visibility text in span tags across multiple components. This ensures uniform styling and structure for visibility toggles.