### PR TITLE
style: adjust max-height of ScrollContainer for better UI consistency

### DIFF
--- a/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
@@ -140,7 +140,7 @@ export default async function Page({ params }: Props) {
 							<ProtectedElement session={session} filter={showPlayer}>
 								{status === 'HOST' && kicks > 0 && (
 									<div className="flex bg-card rounded-md flex-col">
-										<ScrollContainer className="grid gap-2 p-2 min-w-[300px] md:max-w-[500px] w-full md:w-fit max-h-[50vh]">
+										<ScrollContainer className="grid gap-2 p-2 min-w-[300px] md:max-w-[500px] w-full md:w-fit max-h-[500px]">
 											<Suspense
 												fallback={
 													<Skeletons number={kicks}>


### PR DESCRIPTION
The max-height of the ScrollContainer was changed from '50vh' to '500px' to ensure a more consistent and predictable layout across different screen sizes. This adjustment improves the user experience by preventing excessive scrolling on smaller screens.