### PR TITLE
style(ui): increase height of plugin cards for better visibility

### DIFF
--- a/app/[locale]/(main)/servers/[id]/plugins/download-plugin-list.tsx
+++ b/app/[locale]/(main)/servers/[id]/plugins/download-plugin-list.tsx
@@ -38,7 +38,7 @@ export default function DownloadPluginList() {
 						queryFn={(axios, params) => getPlugins(axios, params)}
 						skeleton={{
 							amount: 20,
-							item: <Skeleton className="h-40 min-h-40" />,
+							item: <Skeleton className="h-48 min-h-48" />,
 						}}
 					>
 						{(page) => page.map((plugin) => <AddServerPluginCard key={plugin.id} plugin={plugin} />)}
@@ -51,7 +51,7 @@ export default function DownloadPluginList() {
 						queryFn={getPlugins}
 						skeleton={{
 							amount: 20,
-							item: <Skeleton className="h-40 min-h-40" />,
+							item: <Skeleton className="h-48 min-h-48" />,
 						}}
 					>
 						{(page) => page.map((plugin) => <AddServerPluginCard key={plugin.id} plugin={plugin} />)}
@@ -119,7 +119,7 @@ function AddServerPluginCard({ plugin }: AddServerPluginCardProps) {
 	return (
 		<motion.button
 			className={cn(
-				'relative border flex h-40 min-h-40 w-full flex-col items-start justify-start gap-2 overflow-hidden rounded-md bg-card p-4 text-start',
+				'relative border flex h-48 min-h-48 w-full flex-col items-start justify-start gap-2 overflow-hidden rounded-md bg-card p-4 text-start',
 				{
 					'hover:border-brand': state !== 'up-to-date',
 					'opacity-50': state === 'up-to-date',

--- a/components/server/server-plugin-card.tsx
+++ b/components/server/server-plugin-card.tsx
@@ -50,7 +50,7 @@ export default function ServerPluginCard({ serverId, plugin: { name, filename, m
 	});
 
 	return (
-		<div className="relative flex flex-col min-h-40 h-40 gap-1 overflow-hidden rounded-md bg-card p-2 border">
+		<div className="relative flex flex-col min-h-48 h-48 gap-1 overflow-hidden rounded-md bg-card p-2 border">
 			<h2 className="line-clamp-1 overflow-hidden text-ellipsis whitespace-normal text-nowrap space-x-1">
 				{repo ? (
 					<a href={`https://github.com/${repo}`}>


### PR DESCRIPTION
The height of plugin cards was increased from 40 to 48 units to improve visibility and readability of the content within the cards. This change was applied consistently across all related components to maintain a uniform UI experience.