### PR TITLE
fix(json-display): remove redundant JSON.parse to prevent double parsing

### DIFF
--- a/components/common/json-display.tsx
+++ b/components/common/json-display.tsx
@@ -1,3 +1,3 @@
-export default function JsonDisplay({ json }: { json: string }) {
-	return <pre>{JSON.stringify(JSON.parse(json), null, 2)}</pre>;
+export default function JsonDisplay({ json }: { json: any }) {
+	return <pre>{JSON.stringify(json, null, 2)}</pre>;
 }


### PR DESCRIPTION
The JSON.parse was redundant since the input `json` is already a parsed object. This change avoids unnecessary double parsing, which could lead to errors if the input is not a valid JSON string.