### PR TITLE
style(json-display): improve readability and formatting of JSON display

### DIFF
--- a/components/common/json-display.tsx
+++ b/components/common/json-display.tsx
@@ -1,3 +1,3 @@
 export default function JsonDisplay({ json }: { json: any }) {
-	return <pre>{JSON.stringify(json, null, 2)}</pre>;
+	return <pre className="text-wrap w-full">{JSON.stringify(json, null, '\t')}</pre>;
 }


### PR DESCRIPTION
Add `text-wrap` and `w-full` classes to ensure proper text wrapping and full width. Use tab character for indentation to enhance readability.