### PR TITLE
fix(kick-list): filter out expired kicks to prevent display

### DIFF
--- a/app/[locale]/(main)/servers/[id]/(dashboard)/kick-list.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/kick-list.tsx
@@ -36,6 +36,7 @@ export default function KickList({ id }: KickListProps) {
 			</h3>
 			<Divider />
 			{Object.entries(data) //
+				.filter(([_, untilTime]) => untilTime > Date.now()) //
 				.map(([ip, untilTime]) => (
 					<KickCard key={ip} serverId={id} kick={{ ip, untilTime }} />
 				))}


### PR DESCRIPTION
Added a filter to the kick list to ensure only active kicks (those with `untilTime` greater than the current time) are displayed. This prevents outdated or expired kicks from showing up in the UI.