### PR TITLE
style(skeleton): adjust max-height for lg breakpoint in detail skeleton

### DIFF
--- a/components/skeleton/detail.skeleton.tsx
+++ b/components/skeleton/detail.skeleton.tsx
@@ -8,7 +8,7 @@ export default function DetailSkeleton() {
 	return (
 		<div className="absolute h-full w-full bg-background p-2 backdrop-blur-sm">
 			<div className="relative h-full flex flex-col lg:grid lg:grid-cols-[1fr_400px] lg:divide-x overflow-auto">
-				<div className="p-2 h-full overflow-auto flex justify-center max-h-[50vh]">
+				<div className="p-2 h-full overflow-auto flex justify-center max-h-[50vh] lg:max-h-full">
 					<Skeleton className="object-cover w-full aspect-square rounded-lg" />
 				</div>
 				<div className="flex flex-col gap-2 p-2 h-full">


### PR DESCRIPTION
The max-height property for the lg breakpoint in the detail skeleton component was updated to ensure consistent layout behavior across different screen sizes. This change improves the visual consistency and responsiveness of the component.