### PR TITLE
fix(i18n): add version query param to translation load paths

### DIFF
--- a/app/[locale]/(main)/servers/[id]/setting/server-update-form.tsx
+++ b/app/[locale]/(main)/servers/[id]/setting/server-update-form.tsx
@@ -136,7 +136,7 @@ export default function ServerUpdateForm({ server }: Props) {
 						render={({ field, fieldState }) => (
 							<FormItem className="grid">
 								<FormLabel>
-									<Tran text="server.image" />
+									<Tran text="server.image"  />
 								</FormLabel>
 								<FormControl>
 									<ComboBox

--- a/i18n/client.ts
+++ b/i18n/client.ts
@@ -34,7 +34,7 @@ export function getClientOptions(lng = defaultLocale, ns = defaultNamespace) {
 					prefix: i18nCachePrefix,
 				},
 				{
-					loadPath: `${env.url.api}/translations/{{lng}}/{{ns}}`,
+					loadPath: `${env.url.api}/translations/{{lng}}/{{ns}}?v=1`,
 					addPath: `${env.url.api}/translations/{{lng}}/{{ns}}/create-missing`,
 				} as HttpBackendOptions,
 			],

--- a/i18n/server.ts
+++ b/i18n/server.ts
@@ -42,7 +42,7 @@ export function getServerOptions(lng = defaultLocale, ns = defaultNamespace) {
 		ns,
 		preload: locales,
 		backend: {
-			loadPath: `${env.url.api}/translations/{{lng}}/{{ns}}`,
+			loadPath: `${env.url.api}/translations/{{lng}}/{{ns}}?v=1`,
 			addPath: `${env.url.api}/translations/{{lng}}/{{ns}}/create-missing`,
 			request(options, url, payload, callback) {
 				if (url.includes('create-missing')) {


### PR DESCRIPTION
This change appends a version query parameter (`v=1`) to the translation load paths in both client and server configurations to ensure the latest translations are fetched and avoid caching issues. Additionally, a minor whitespace fix was applied in the server update form.