### PR TITLE
style(servers): remove redundant CSS classes from dashboard image con…

### DIFF
--- a/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
@@ -195,7 +195,7 @@ export default async function Page({ params }: Props) {
 							</ProtectedElement>
 						</div>
 						{status === 'HOST' && (
-							<div className="flex md:max-w-[50dvw] h-auto rounded-md overflow-hidden landscape:max-h-[50dvh] landscape:max-w-none">
+							<div className="flex h-auto rounded-md overflow-hidden">
 								<Image
 									className="w-full"
 									key={status}

--- a/app/[locale]/(main)/translation/all.table.tsx
+++ b/app/[locale]/(main)/translation/all.table.tsx
@@ -64,7 +64,7 @@ type AllCardProps = {
 };
 
 function AllCard({ translation }: AllCardProps) {
-	const { key, value, keyGroup } = translation;
+	const { id, key, value, keyGroup } = translation;
 
 	return (
 		<div className="flex flex-col gap-1 bg-card p-2 rounded-md border">
@@ -73,6 +73,7 @@ function AllCard({ translation }: AllCardProps) {
 			</div>
 			{locales.map((locale) => (
 				<ValueCard
+					keyId={id}
 					key={locale}
 					tKey={key}
 					keyGroup={keyGroup}
@@ -91,13 +92,14 @@ function AllCard({ translation }: AllCardProps) {
 }
 
 type ValueCardProps = {
+	keyId: string;
 	tKey: string;
 	keyGroup: string;
 	locale: Locale;
 	value: TranslationAllValue;
 };
 
-function ValueCard({ tKey: key, keyGroup, value, locale }: ValueCardProps) {
+function ValueCard({ keyId, tKey: key, keyGroup, value, locale }: ValueCardProps) {
 	const [currentValue, setCurrentValue] = useState(value);
 	const [isEdit, setEdit] = useState(false);
 	const axios = useClientApi();
@@ -144,7 +146,7 @@ function ValueCard({ tKey: key, keyGroup, value, locale }: ValueCardProps) {
 				{currentValue.id && (
 					<EllipsisButton>
 						<Suspense>
-							<DeleteTranslationDialog value={{ key, id: currentValue.id }} />
+							<DeleteTranslationDialog value={{ key, id: keyId }} />
 						</Suspense>
 					</EllipsisButton>
 				)}

--- a/app/[locale]/(main)/translation/compare.table.tsx
+++ b/app/[locale]/(main)/translation/compare.table.tsx
@@ -86,7 +86,7 @@ type CompareCardProps = {
 };
 
 function CompareCard({ translation, language, target }: CompareCardProps) {
-	const { key, id, value, keyGroup } = translation;
+	const { key, keyId, value, keyGroup } = translation;
 	const [currentValue, setCurrentValue] = useState(value[language]);
 
 	const [isEdit, setEdit] = useState(false);
@@ -141,7 +141,7 @@ function CompareCard({ translation, language, target }: CompareCardProps) {
 			</TableCell>
 			<TableCell className="flex justify-center">
 				<EllipsisButton variant="ghost">
-					<DeleteTranslationDialog value={{ key, id }} />
+					<DeleteTranslationDialog value={{ key, id: keyId }} />
 				</EllipsisButton>
 			</TableCell>
 		</TableRow>

--- a/app/[locale]/(main)/translation/page.client.tsx
+++ b/app/[locale]/(main)/translation/page.client.tsx
@@ -41,14 +41,14 @@ const defaultState: {
 
 function format(key: null | boolean) {
 	if (key === null) {
-		return 'translation.all';
+		return 'all';
 	}
 
 	if (key === true) {
-		return 'translation.translated';
+		return 'translated';
 	}
 
-	return 'translation.untranslated';
+	return 'untranslated';
 }
 
 export default function TranslationPage() {

--- a/app/[locale]/(main)/translation/search.table.tsx
+++ b/app/[locale]/(main)/translation/search.table.tsx
@@ -79,7 +79,7 @@ type SearchCardProps = {
 };
 
 function SearchCard({ translation }: SearchCardProps) {
-	const { key, id, value, keyGroup, isTranslated, language: translationLanguage } = translation;
+	const { key, keyId, value, keyGroup, isTranslated, language: translationLanguage } = translation;
 	const [currentValue, setCurrentValue] = useState(value);
 
 	const axios = useClientApi();
@@ -130,7 +130,7 @@ function SearchCard({ translation }: SearchCardProps) {
 			<TableCell>
 				<EllipsisButton variant="ghost">
 					<Suspense>
-						<DeleteTranslationDialog value={{ key, id }} />
+						<DeleteTranslationDialog value={{ key, id: keyId }} />
 					</Suspense>
 				</EllipsisButton>
 			</TableCell>

--- a/types/response/Translation.ts
+++ b/types/response/Translation.ts
@@ -14,6 +14,7 @@ export type TranslationAllValue = {
 };
 
 export type TranslationAll = {
+	id: string;
 	key: string;
 	value: Partial<Record<Locale, TranslationAllValue>>;
 	keyGroup: string;
@@ -21,6 +22,7 @@ export type TranslationAll = {
 
 export type TranslationCompare = {
 	id: string;
+	keyId: string;
 	key: string;
 	value: Record<Locale, string>;
 	keyGroup: string;
@@ -28,6 +30,7 @@ export type TranslationCompare = {
 
 export type Translation = {
 	id: string;
+	keyId: string;
 	key: string;
 	value: string;
 	keyGroup: string;


### PR DESCRIPTION
…tainer

The `md:max-w-[50dvw]` and `landscape:max-h-[50dvh] landscape:max-w-none` classes were unnecessary and potentially conflicting with the responsive behavior. This change simplifies the styling for better maintainability and consistency.