### PR TITLE
fix(sonner): set toast position to top-right

### DIFF
--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -23,6 +23,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
 			style={{
 				gap: 6,
 			}}
+			position='top-right'
 			toastOptions={{
 				classNames: {
 					toast: 'group p-0 group-[.toaster]:bg-card group-[.toaster]:text-foreground group-[.toaster]:shadow-lg',


### PR DESCRIPTION
The toast position was not explicitly set, causing it to default to a potentially undesired location. This change ensures the toast always appears in the top-right corner for better user experience.