### PR TITLE
fix(server-plugin-card): skip rendering if version matches data

### DIFF
--- a/components/server/server-plugin-card.tsx
+++ b/components/server/server-plugin-card.tsx
@@ -120,6 +120,8 @@ function PluginVersion({ id: pluginId, version, filename }: { id: string; versio
 		},
 	});
 
+	if (data?.version === version) return null;
+
 	if (data) {
 		return (
 			<TooltipProvider>


### PR DESCRIPTION
Avoid rendering the PluginVersion component when the version prop matches the fetched data version to prevent unnecessary UI updates.