### PR TITLE
style: reorder class names for consistency and remove unused Divider

### DIFF
--- a/app/[locale]/(main)/medium-nav.footer.tsx
+++ b/app/[locale]/(main)/medium-nav.footer.tsx
@@ -7,7 +7,6 @@ import NotificationDialog from '@/app/[locale]/(main)/notification.dialog';
 import ErrorMessage from '@/components/common/error-message';
 import { SettingIcon } from '@/components/common/icons';
 import InternalLink from '@/components/common/internal-link';
-import Divider from '@/components/ui/divider';
 import UserAvatar from '@/components/user/user-avatar';
 
 import { useNavBar } from '@/context/navbar.context';
@@ -24,12 +23,11 @@ export default function MediumNavFooter() {
 	}
 
 	return (
-		<div className="space-y-1 mt-auto">
-			<Divider />
+		<div className="mt-auto space-y-1">
 			<NotificationDialog />
 			<InternalLink
-				className={cn('flex h-9 items-center justify-center rounded-md p-1 hover:bg-brand hover:text-brand-foreground', {
-					'justify-start gap-2 py-2': visible,
+				className={cn('flex justify-center items-center p-1 h-9 rounded-md hover:bg-brand hover:text-brand-foreground', {
+					'gap-2 justify-start py-2': visible,
 				})}
 				href="/users/@me/setting"
 				aria-label="Setting"

--- a/app/[locale]/(main)/medium-navbar-collapse.tsx
+++ b/app/[locale]/(main)/medium-navbar-collapse.tsx
@@ -28,7 +28,7 @@ export default function MediumNavbarCollapse({ children }: Props) {
 
 	return (
 		<motion.div
-			className={cn('relative gap-2 h-full overflow-hidden bg-card min-w-nav w-full flex-col p-1 flex border-r', { 'p-2': visible })}
+			className={cn('flex overflow-hidden relative flex-col gap-2 p-1 w-full h-full border-r divide-y bg-card min-w-nav', { 'p-2': visible })}
 			variants={sidebarVariants}
 			initial={visible ? { width: sidebarVariants.open.width } : { width: sidebarVariants.closed.width }}
 			animate={visible ? 'open' : 'closed'}

--- a/components/search/name-tag-search.tsx
+++ b/components/search/name-tag-search.tsx
@@ -242,7 +242,7 @@ export default function NameTagSearch({ className, type, useSort = true, useTag 
 								<FilterTags filter={filter} filterBy={filterBy} tags={tags} handleTagGroupChange={handleTagGroupChange} />
 							</ScrollContainer>
 							<Divider />
-							<CardFooter className="flex gap-1 justify-between p-0 w-full">
+							<CardFooter className="flex gap-1 justify-between px-0 pt-1 pb-0 w-full border-t">
 								<TagSettingDialog />
 								<Button onClick={handleHideFilterDialog} variant="primary">
 									{isChanged ? <Tran text="search" /> : <Tran text="close" />}


### PR DESCRIPTION
Refactor class names in medium-navbar-collapse.tsx and medium-nav.footer.tsx to maintain a consistent order and remove the unused Divider component. This improves readability and reduces unnecessary code.