### PR TITLE
style(button): adjust secondary button width to fit content

### DIFF
--- a/components/button/delete.button.tsx
+++ b/components/button/delete.button.tsx
@@ -29,7 +29,7 @@ const buttonVariants = cva('hover:bg-destructive/80', {
 		},
 		size: {
 			default: '',
-			secondary: 'h-9 px-3 py-2',
+			secondary: 'h-9 px-3 py-2 w-fit',
 			sm: 'h-8 rounded-md px-3 text-xs',
 			lg: 'h-10 rounded-md px-8',
 			icon: 'h-7 w-7 aspect-square p-0',


### PR DESCRIPTION
The `w-fit` class was added to the secondary button variant to ensure the width of the button fits its content, improving visual consistency and alignment with other button styles.