### PR TITLE
refactor(map, schematic): replace `back()` with `router.push()` for c…

### DIFF
--- a/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
@@ -177,7 +177,7 @@ export default async function Page({ params }: Props) {
 								</div>
 							</div>
 							{status === 'HOST' && (
-								<div className="flex h-auto w-full md:max-w-[30vw] rounded-md overflow-hidden">
+								<div className="flex h-auto w-full md:max-w-[40vw] rounded-md overflow-hidden">
 									<Image
 										className="object-contain overflow-hidden w-full h-auto rounded-md border"
 										key={status}

--- a/components/map/delete-map.button.tsx
+++ b/components/map/delete-map.button.tsx
@@ -20,7 +20,7 @@ type DeleteMapButtonProps = {
 
 export function DeleteMapButton({ id, name, variant }: DeleteMapButtonProps) {
 	const axios = useClientApi();
-	const { back } = useRouter();
+	const router = useRouter();
 	const { invalidateByKey } = useQueriesData();
 
 	const { mutate, isPending } = useMutation({
@@ -29,8 +29,8 @@ export function DeleteMapButton({ id, name, variant }: DeleteMapButtonProps) {
 		},
 		mutationFn: (id: string) => deleteMap(axios, id),
 		onSuccess: () => {
-			back();
 			toast.success(<Tran text="delete-success" />);
+			router.push('/admin/maps');
 		},
 		onError: (error) => {
 			toast.error(<Tran text="delete-fail" />, { error });

--- a/components/schematic/delete-schematic.button.tsx
+++ b/components/schematic/delete-schematic.button.tsx
@@ -20,7 +20,7 @@ type DeleteSchematicButtonProps = {
 
 export default function DeleteSchematicButton({ id, name, variant }: DeleteSchematicButtonProps) {
 	const axios = useClientApi();
-	const { back } = useRouter();
+	const router = useRouter();
 	const { invalidateByKey } = useQueriesData();
 
 	const { mutate, isPending } = useMutation({
@@ -31,7 +31,7 @@ export default function DeleteSchematicButton({ id, name, variant }: DeleteSchem
 		onSuccess: () => {
 			invalidateByKey(['schematics']);
 			toast.success(<Tran text="delete-success" />);
-			back();
+			router.push('/admin/schematics');
 		},
 		onError: (error) => {
 			toast.error(<Tran text="delete-fail" />, { error });

--- a/components/server/server-plugin-card.tsx
+++ b/components/server/server-plugin-card.tsx
@@ -161,7 +161,12 @@ function PluginVersion({ id: pluginId, version, filename }: { id: string; versio
 			<TooltipProvider>
 				<Tooltip>
 					<TooltipTrigger asChild>
-						<Button className="animate-bounce" variant="secondary" onClick={() => mutate(pluginId)} disabled={isPending}>
+						<Button
+							className={isPending ? '' : 'animate-bounce'}
+							variant="secondary"
+							onClick={() => mutate(pluginId)}
+							disabled={isPending}
+						>
 							{isPending ? (
 								<LoadingSpinner />
 							) : (


### PR DESCRIPTION
…onsistent navigation

Replace `back()` with `router.push()` in delete operations for both map and schematic components to ensure consistent and explicit navigation after successful deletion. This change avoids reliance on the browser's history stack and ensures users are redirected to the correct admin pages.