### PR TITLE
fix(map/schematic): preserve query params after delete operation

### DIFF
--- a/components/map/delete-map.button.tsx
+++ b/components/map/delete-map.button.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 import DeleteButton, { DeleteButtonProps } from '@/components/button/delete.button';
 import Tran from '@/components/common/tran';
@@ -20,6 +20,7 @@ type DeleteMapButtonProps = {
 
 export function DeleteMapButton({ id, name, variant }: DeleteMapButtonProps) {
 	const axios = useClientApi();
+	const params = useSearchParams();
 	const router = useRouter();
 	const { invalidateByKey } = useQueriesData();
 
@@ -30,7 +31,7 @@ export function DeleteMapButton({ id, name, variant }: DeleteMapButtonProps) {
 		mutationFn: (id: string) => deleteMap(axios, id),
 		onSuccess: () => {
 			toast.success(<Tran text="delete-success" />);
-			router.push('/admin/maps');
+			router.push('/admin/maps?' + params.toString());
 		},
 		onError: (error) => {
 			toast.error(<Tran text="delete-fail" />, { error });

--- a/components/schematic/delete-schematic.button.tsx
+++ b/components/schematic/delete-schematic.button.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 import DeleteButton, { DeleteButtonProps } from '@/components/button/delete.button';
 import Tran from '@/components/common/tran';
@@ -20,6 +20,7 @@ type DeleteSchematicButtonProps = {
 
 export default function DeleteSchematicButton({ id, name, variant }: DeleteSchematicButtonProps) {
 	const axios = useClientApi();
+	const params = useSearchParams();
 	const router = useRouter();
 	const { invalidateByKey } = useQueriesData();
 
@@ -31,7 +32,7 @@ export default function DeleteSchematicButton({ id, name, variant }: DeleteSchem
 		onSuccess: () => {
 			invalidateByKey(['schematics']);
 			toast.success(<Tran text="delete-success" />);
-			router.push('/admin/schematics');
+			router.push('/admin/schematics?' + params.toString());
 		},
 		onError: (error) => {
 			toast.error(<Tran text="delete-fail" />, { error });


### PR DESCRIPTION
Ensure query parameters are retained when redirecting after deleting a map or schematic. This prevents loss of user context, such as filters or pagination settings.