### PR TITLE
refactor(types): remove empty message content check in groupMessage

### DIFF
--- a/app/[locale]/(main)/servers/[id]/plugins/plugin-list.tsx
+++ b/app/[locale]/(main)/servers/[id]/plugins/plugin-list.tsx
@@ -19,7 +19,7 @@ export default function PluginList({ id }: { id: string }) {
 	}
 
 	return (
-		<ScrollContainer className="w-full gap-2 md:grid-cols-2 lg:grid-cols-3 grid-flow-row">
+		<ScrollContainer className="grid w-full gap-2 md:grid-cols-2 lg:grid-cols-3 grid-flow-row">
 			{data?.map((plugin) => <ServerPluginCard serverId={id} key={plugin.filename} plugin={plugin} />)}
 		</ScrollContainer>
 	);

--- a/types/response/Message.ts
+++ b/types/response/Message.ts
@@ -24,10 +24,6 @@ export function groupMessage(messages: Message[]): MessageGroup[] {
 	const result: MessageGroup[] = [];
 
 	for (const message of messages) {
-		if (message.content === '' || message.content === '\n') {
-			continue;
-		}
-
 		if (result.length === 0) {
 			result.push({
 				id: message.id,


### PR DESCRIPTION
The check for empty or newline message content was removed to simplify the grouping logic. This change ensures all messages are processed uniformly, improving code maintainability.