### PR TITLE
fix(metrics): set default filter to metricFilters[4]

### DIFF
--- a/app/[locale]/(main)/servers/[id]/metrics/page.tsx
+++ b/app/[locale]/(main)/servers/[id]/metrics/page.tsx
@@ -24,7 +24,7 @@ type Filter = (typeof metricFilters)[number];
 
 export default function Page({ params }: { params: Promise<{ id: string }> }) {
 	const { id } = use(params);
-	const [filter, setFilter] = useState<Filter>(metricFilters[0]);
+	const [filter, setFilter] = useState<Filter>(metricFilters[4]);
 
 	return (
 		<div className="p-2 flex flex-col gap-2">


### PR DESCRIPTION
The default filter was incorrectly set to metricFilters[0], which caused the metrics page to display incorrect data initially. This change sets the default filter to metricFilters[4] to ensure the correct data is shown when the page loads.