### PR TITLE
fix(chat-panel): update chat room identifier from SERVER_CONSOLE to S…

### DIFF
--- a/app/[locale]/(main)/servers/[id]/(dashboard)/chat-panel.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/chat-panel.tsx
@@ -17,7 +17,7 @@ export default async function ChatPanel({ id }: Props) {
 			<div className="overflow-x-hidden bg-card">
 				<ServerConsolePage />
 			</div>
-			<ChatInput room={`SERVER_CONSOLE-${id}`} />
+			<ChatInput room={`SERVER_CHAT-${id}`} />
 		</div>
 	);
 }


### PR DESCRIPTION
…ERVER_CHAT

The room identifier was incorrectly using SERVER_CONSOLE prefix which didn't match the actual chat functionality. Changed to SERVER_CHAT to properly identify chat rooms.