### PR TITLE
style(ui): adjust padding and styling for chat components

### DIFF
--- a/app/[locale]/(main)/chat/page.client.tsx
+++ b/app/[locale]/(main)/chat/page.client.tsx
@@ -72,7 +72,7 @@ function GlobalChatInput() {
 				</div>
 			}
 		>
-			<ChatInput room="GLOBAL" />
+			<ChatInput room="GLOBAL" className="p-2" />
 		</ProtectedElement>
 	);
 }

--- a/app/[locale]/(main)/logs/live-log.tsx
+++ b/app/[locale]/(main)/logs/live-log.tsx
@@ -18,7 +18,7 @@ export default function LiveLog() {
 					</MessageList>
 				</div>
 			</div>
-			<ChatInput room="LOG" />
+			<ChatInput room="LOG" className="p-2" />
 		</div>
 	);
 }

--- a/app/[locale]/(main)/servers/[id]/(dashboard)/chat-list.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/chat-list.tsx
@@ -11,7 +11,7 @@ export default function ServerConsolePage() {
 
 	return (
 		<MessageList
-			className="flex h-full flex-col gap-1"
+			className="flex h-full flex-col gap-1 max-h-screen"
 			queryKey={['servers', id, 'chat']}
 			room={`SERVER_CHAT-${id}`}
 			params={{ size: 50 }}

--- a/app/[locale]/(main)/servers/[id]/(dashboard)/chat-panel.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/chat-panel.tsx
@@ -14,7 +14,7 @@ type Props = {
 export default async function ChatPanel({ id }: Props) {
 	return (
 		<div className="grid h-full w-full grid-rows-[1fr_auto] overflow-hidden">
-			<div className="overflow-x-hidden bg-card">
+			<div className="overflow-x-hidden bg-card rounded-md border">
 				<ServerConsolePage />
 			</div>
 			<ChatInput room={`SERVER_CHAT-${id}`} />

--- a/app/[locale]/(main)/servers/[id]/console/console-input.tsx
+++ b/app/[locale]/(main)/servers/[id]/console/console-input.tsx
@@ -33,6 +33,7 @@ export default function ConsoleInput({ id, room }: { room: string; id: string })
 
 	return (
 		<ChatInput
+			className="p-2"
 			room={room}
 			placeholder="/help"
 			onKeyPress={(event) => {

--- a/components/messages/chat-input.tsx
+++ b/components/messages/chat-input.tsx
@@ -108,7 +108,7 @@ export default function ChatInput({ className, room, placeholder, autocomplete, 
 	}
 	return (
 		<form
-			className={cn('flex min-h-12 flex-1 gap-2 p-2 border-t h-fit', className)}
+			className={cn('flex min-h-12 flex-1 gap-2 border-t h-fit', className)}
 			name="text"
 			onSubmit={(event) => {
 				handleFormSubmit();


### PR DESCRIPTION
- Add consistent padding to ChatInput components across different pages
- Remove redundant padding from ChatInput form to avoid double padding
- Improve chat panel styling with rounded corners and border
- Set max height for chat list to prevent overflow