### PR TITLE
fix(chat-panel): adjust chat panel width to prevent overflow

### DIFF
--- a/app/[locale]/(main)/servers/[id]/(dashboard)/chat-panel.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/chat-panel.tsx
@@ -14,7 +14,7 @@ type Props = {
 
 export default async function ChatPanel({ id }: Props) {
 	return (
-		<div className="grid flex-1 w-full grid-rows-[1fr_auto] overflow-hidden bg-card rounded-md border min-h-[50dvh]">
+		<div className="grid flex-1 w-full max-w-[min(100vw_350px)] grid-rows-[1fr_auto] overflow-hidden bg-card rounded-md border min-h-[50dvh]">
 			<div className="overflow-x-hidden p-2 space-y-2">
 				<h3 className="font-semibold">
 					<Tran asChild text="server.chat" />

--- a/app/[locale]/(main)/servers/[id]/(dashboard)/chat-panel.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/chat-panel.tsx
@@ -14,7 +14,7 @@ type Props = {
 
 export default async function ChatPanel({ id }: Props) {
 	return (
-		<div className="grid flex-1 w-full max-w-[min(100vw_350px)] grid-rows-[1fr_auto] overflow-hidden bg-card rounded-md border min-h-[50dvh]">
+		<div className="grid flex-1 w-full md:max-w-[min(100vw_350px)] grid-rows-[1fr_auto] overflow-hidden bg-card rounded-md border min-h-[50dvh]">
 			<div className="overflow-x-hidden p-2 space-y-2">
 				<h3 className="font-semibold">
 					<Tran asChild text="server.chat" />

--- a/app/[locale]/(main)/servers/[id]/(dashboard)/init-server-button.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/init-server-button.tsx
@@ -63,7 +63,7 @@ export default function InitServerButton({ id }: Props) {
 	return (
 		<HasServerMap id={id}>
 			<Button
-				className="w-20 border-none text-foreground bg-primary-foreground"
+				className="w-20 border-none text-foreground bg-primary"
 				title="Init"
 				variant="primary"
 				disabled={isPending}

--- a/components/messages/message-card.tsx
+++ b/components/messages/message-card.tsx
@@ -32,7 +32,7 @@ export function MessageCard({ className, message }: Props) {
 				<Skeleton className="flex justify-center items-center capitalize rounded-full border size-8 min-h-8 min-w-8 border-border" />
 			)}
 			<div className="overflow-hidden">
-				<div className="flex gap-2 justify-between">
+				<div className="flex gap-2">
 					{data ? (
 						<ColorAsRole className="capitalize" roles={data.roles}>
 							{data.name}


### PR DESCRIPTION
The chat panel was extending beyond the viewport on smaller screens. Added max-width constraint to ensure it stays within bounds while maintaining a minimum width of 350px.