### PR TITLE
fix(servers): reorder server action buttons for better logical flow

### DIFF
--- a/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
@@ -171,9 +171,9 @@ export default async function Page({ params }: Props) {
 					<footer className="flex gap-8 flex-wrap justify-between h-9">
 						<ProtectedElement session={session} filter={canAccess}>
 							<div className="flex flex-row gap-2 justify-end items-center ml-auto">
-								{status === 'HOST' && <PauseServerButton id={id} />}
 								{status !== 'DELETED' && <RemoveServerButton id={id} />}
 								{(status === 'HOST' || status === 'UP') && <ShutdownServerButton id={id} />}
+								{status === 'HOST' && <PauseServerButton id={id} />}
 								{status === 'HOST' ? (
 									<StopServerButton id={id} />
 								) : status === 'UP' ? (


### PR DESCRIPTION
The PauseServerButton was moved after ShutdownServerButton to maintain consistent ordering of destructive actions. This improves the UI's logical flow where more severe actions appear later in the sequence.