### PR TITLE
feat(server-card): display gamemode alongside mode in server card

### DIFF
--- a/app/[locale]/(main)/navbar-link.tsx
+++ b/app/[locale]/(main)/navbar-link.tsx
@@ -26,7 +26,7 @@ export default function NavbarLink({ name, icon, path, regex, filter }: Props) {
 	return hasAccess(session, filter) ? (
 		<InternalLink
 			className={cn(
-				'flex h-9 items-center text-foreground/60 capitalize justify-center rounded-md p-1 hover:bg-brand hover:text-brand-foreground text-sm',
+				'flex h-9 animate-appear items-center text-foreground/60 capitalize justify-center rounded-md p-1 hover:bg-brand hover:text-brand-foreground text-sm',
 				{
 					'bg-brand text-brand-foreground': regex.some((r) => currentPath.match(r)),
 					'justify-start gap-2 py-2': visible,

--- a/app/[locale]/(main)/servers/[id]/(dashboard)/mismatch-panel.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/mismatch-panel.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import ErrorMessage from '@/components/common/error-message';
+
+import useClientApi from '@/hooks/use-client';
+import usePathId from '@/hooks/use-path-id';
+import { getServerMismatch } from '@/query/server';
+
+import { useQuery } from '@tanstack/react-query';
+
+export default function MismatchPanel() {
+	const id = usePathId();
+	const axios = useClientApi();
+	const { data, isLoading, isError, error } = useQuery({
+		queryKey: ['server', id, 'mismatch'],
+		queryFn: () => getServerMismatch(axios, id),
+	});
+
+	if (isError) {
+		return <ErrorMessage error={error} />;
+	}
+
+	if (isLoading) {
+		return null;
+	}
+
+	if (!data || data.length === 0) {
+		return null;
+	}
+
+	return (
+		<section className="flex gap-2 flex-wrap">
+			{data.map((mismatch) => (
+				<div key={mismatch}>{mismatch}</div>
+			))}
+		</section>
+	);
+}

--- a/app/[locale]/(main)/servers/[id]/(dashboard)/mismatch-panel.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/mismatch-panel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import ErrorMessage from '@/components/common/error-message';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 
 import useClientApi from '@/hooks/use-client';
 import usePathId from '@/hooks/use-path-id';
@@ -29,10 +30,24 @@ export default function MismatchPanel() {
 	}
 
 	return (
-		<section className="flex gap-2 flex-wrap">
-			{data.map((mismatch) => (
-				<div key={mismatch}>{mismatch}</div>
-			))}
-		</section>
+		<Popover>
+			<PopoverTrigger asChild>
+				<span className="text-sm text-destructive-foreground">
+					<span>{data[0]}</span>
+					{data.length > 1 && (
+						<span className="inline-flex size-4 min-w-4 rounded-md bg-destructive-foreground">{data.length - 1}+</span>
+					)}
+				</span>
+			</PopoverTrigger>
+			<PopoverContent>
+				<section className="flex gap-2 text-sm w-full overflow-hidden text-ellipsis flex-col max-h-[50vh] overflow-y-auto">
+					{data.map((mismatch) => (
+						<div className="border rounded-full border-destructive-foreground text-ellipsis" key={mismatch}>
+							{mismatch}
+						</div>
+					))}
+				</section>
+			</PopoverContent>
+		</Popover>
 	);
 }

--- a/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
@@ -6,7 +6,6 @@ import React, { Fragment, Suspense } from 'react';
 
 import { getCachedServer } from '@/app/[locale]/(main)/servers/[id]/(dashboard)/action';
 import ChatPanel from '@/app/[locale]/(main)/servers/[id]/(dashboard)/chat-panel';
-import PauseServerButton from '@/app/[locale]/(main)/servers/[id]/(dashboard)/pause-server-button';
 
 import CopyButton from '@/components/button/copy.button';
 import { CatchError } from '@/components/common/catch-error';
@@ -16,7 +15,7 @@ import InternalLink from '@/components/common/internal-link';
 import ScrollContainer from '@/components/common/scroll-container';
 import Tran from '@/components/common/tran';
 import RamUsageChart from '@/components/metric/ram-usage-chart';
-import { CpuProgress } from '@/components/server/cpu-progress';
+import CpuProgress from '@/components/server/cpu-progress';
 import ServerStatusBadge from '@/components/server/server-status-badge';
 import Divider from '@/components/ui/divider';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -29,6 +28,9 @@ import ProtectedElement from '@/layout/protected-element';
 import { isError } from '@/lib/error';
 import { generateAlternate } from '@/lib/i18n.utils';
 import { byteToSize, formatTitle, hasAccess } from '@/lib/utils';
+
+const MismatchPanel = dynamic(() => import('@/app/[locale]/(main)/servers/[id]/(dashboard)/mismatch-panel'));
+const PauseServerButton = dynamic(() => import('@/app/[locale]/(main)/servers/[id]/(dashboard)/pause-server-button'));
 
 export const experimental_ppr = true;
 
@@ -102,7 +104,7 @@ export default async function Page({ params }: Props) {
 	return (
 		<ScrollContainer className="flex p-2 flex-col gap-2 h-full">
 			<div className="grid grid-rows-[auto_1fr] gap-2 w-full h-full">
-				<div className="flex flex-col gap-4 p-2 w-full rounded-md border bg-card">
+				<div className="flex flex-col gap-2 p-2 w-full rounded-md border bg-card">
 					<header className="flex gap-2 items-center relative">
 						{avatar && <Image className="size-16 object-cover rounded-md" src={avatar} width={64} height={64} alt={name} />}
 						<div className="flex flex-col gap-1">
@@ -112,7 +114,7 @@ export default async function Page({ params }: Props) {
 								<IdUserCard id={userId} />
 							</span>
 						</div>
-						<div className="absolute top-1 left-1 p-2">
+						<div className="absolute top-1 right-1 p-2 backdrop-brightness-50 backdrop-blur-sm">
 							<InternalLink href="/setting">
 								<CogIcon className="size-4" />
 							</InternalLink>
@@ -169,6 +171,11 @@ export default async function Page({ params }: Props) {
 					)}
 					<Divider />
 					<footer className="flex gap-8 flex-wrap justify-between h-9">
+						<ProtectedElement session={session} filter={canAccess}>
+							<Suspense>
+								<MismatchPanel />
+							</Suspense>
+						</ProtectedElement>
 						<ProtectedElement session={session} filter={canAccess}>
 							<div className="flex flex-row gap-2 justify-end items-center ml-auto">
 								{status !== 'DELETED' && <RemoveServerButton id={id} />}

--- a/components/common/error-message.tsx
+++ b/components/common/error-message.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
+import ReportErrorDialog from '@/components/common/report-error.dialog';
 import Tran from '@/components/common/tran';
 
-import { getErrorMessage } from '@/lib/error';
+import { getErrorMessage, reportError } from '@/lib/error';
 import { cn } from '@/lib/utils';
 
 type Props = {
@@ -12,9 +13,23 @@ type Props = {
 export default function ErrorMessage({ className, error }: Props) {
 	const message = getErrorMessage(error);
 
+	useEffect(() => {
+		reportError(error);
+	}, [error]);
+
 	if (message) {
-		return <span className={cn('text-destructive-foreground font-semibold p-2 text-sm', className)}>{message}</span>;
+		return (
+			<span className={cn('text-destructive-foreground font-semibold p-2 text-sm space-x-1', className)}>
+				{message}
+				<ReportErrorDialog />
+			</span>
+		);
 	}
 
-	return <Tran className={cn('text-destructive-foreground font-semibold p-2 text-sm', className)} text="unknown-error" />;
+	return (
+		<span className={cn('text-destructive-foreground font-semibold p-2 text-sm space-x-1', className)}>
+			<Tran text="unknown-error" />;
+			<ReportErrorDialog />
+		</span>
+	);
 }

--- a/components/common/error-screen.tsx
+++ b/components/common/error-screen.tsx
@@ -2,10 +2,11 @@
 
 import { useEffect, useMemo } from 'react';
 
+import ReportErrorDialog from '@/components/common/report-error.dialog';
 import Tran from '@/components/common/tran';
 import { Button } from '@/components/ui/button';
 
-import { TError, getErrorMessage } from '@/lib/error';
+import { TError, getErrorMessage, reportError } from '@/lib/error';
 
 export default function ErrorScreen({ error }: { error: TError }) {
 	const message = useMemo(() => getErrorMessage(error), [error]);
@@ -18,14 +19,7 @@ export default function ErrorScreen({ error }: { error: TError }) {
 		<div className="error flex h-full w-full flex-col items-center justify-center gap-2 bg-background p-2">
 			<h2 className="text-base font-bold">{message}</h2>
 			<div className="grid grid-cols-2 items-center justify-center gap-2">
-				<a
-					className="h-9 flex-1 text-nowrap rounded-md text-sm border border-border justify-center items-center px-4 py-2"
-					href="https://discord.gg/DCX5yrRUyp"
-					target="_blank"
-					rel="noopener noreferrer"
-				>
-					<Tran text="report-error-at" />
-				</a>
+				<ReportErrorDialog />
 				<Button className="flex-1" variant="primary" onClick={() => window.location.reload()}>
 					<Tran text="refresh" />
 				</Button>

--- a/components/common/report-error.dialog.tsx
+++ b/components/common/report-error.dialog.tsx
@@ -1,0 +1,21 @@
+import dynamic from 'next/dynamic';
+import { Suspense } from 'react';
+
+import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog';
+
+const ReportErrorForm = dynamic(() => import('@/components/common/report-error.form'));
+
+export default function ReportErrorDialog() {
+	return (
+		<Dialog>
+			<DialogTrigger asChild>
+				<span className="underline text-foreground">Report Error</span>
+			</DialogTrigger>
+			<Suspense>
+				<DialogContent>
+					<ReportErrorForm />
+				</DialogContent>
+			</Suspense>
+		</Dialog>
+	);
+}

--- a/components/common/report-error.form.tsx
+++ b/components/common/report-error.form.tsx
@@ -1,0 +1,19 @@
+import Tran from '@/components/common/tran';
+
+export default function ReportErrorForm() {
+	return (
+		<div className="flex flex-col gap-4">
+			<a
+				className="h-9 flex-1 text-nowrap rounded-md text-sm border border-border justify-center items-center px-4 py-2"
+				href="https://discord.gg/DCX5yrRUyp"
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				<Tran text="report-error-at" />
+			</a>
+			<label htmlFor="error-report" className="text-sm font-medium text-gray-900">
+				Report Error
+			</label>
+		</div>
+	);
+}

--- a/components/server/cpu-progress.tsx
+++ b/components/server/cpu-progress.tsx
@@ -13,7 +13,7 @@ const CpuProgress = React.forwardRef<
 	const [percent, setPercent] = React.useState(0);
 
 	React.useEffect(() => {
-		const timeout = setTimeout(() => setPercent(value || 0), 100);
+		const timeout = setTimeout(() => setPercent(Math.min(100, value || 0)), 50);
 
 		return () => clearTimeout(timeout);
 	}, [value]);
@@ -33,4 +33,4 @@ const CpuProgress = React.forwardRef<
 });
 CpuProgress.displayName = 'CpuProgress';
 
-export { CpuProgress };
+export default CpuProgress;

--- a/components/server/server-card.tsx
+++ b/components/server/server-card.tsx
@@ -14,7 +14,7 @@ type MyServerInstancesCardProps = {
 };
 
 export default function ServerCard({
-	server: { id, name, players, port, status, mapName, mode, isOfficial, avatar },
+	server: { id, name, players, port, status, mapName, mode, gamemode, isOfficial, avatar },
 }: MyServerInstancesCardProps) {
 	return (
 		<InternalLink
@@ -44,7 +44,11 @@ export default function ServerCard({
 					</div>
 					<div className="flex flex-col gap-0.5">
 						<Tran asChild text="server.game-mode" />
-						<span className="capitalize">{mode.toLocaleLowerCase()}</span>
+						<span>
+							<span>{mode}</span>
+							{gamemode && '/'}
+							{gamemode && <span>{gamemode}</span>}
+						</span>
 					</div>
 					<div className="flex flex-col gap-0.5">
 						<Tran asChild text="server.players" />

--- a/lib/error.ts
+++ b/lib/error.ts
@@ -1,8 +1,11 @@
-import env from "@/constant/env";
+import env from '@/constant/env';
+
+export const errors: string[] = [];
 
 export function reportError(error: any) {
 	if (process.env.NODE_ENV === 'production') {
 		fetch(`${env.url.api}/error`, { method: 'POST', body: getLoggedErrorMessage(error) });
+		errors.push(error);
 	}
 }
 

--- a/query/server.ts
+++ b/query/server.ts
@@ -40,8 +40,14 @@ export async function getServerPlayers(axios: AxiosInstance, id: string): Promis
 	return result.data;
 }
 
-export async function getServerState(axios: AxiosInstance, id: string): Promise<Object> {
+export async function getServerState(axios: AxiosInstance, id: string): Promise<any> {
 	const result = await axios.get(`/servers/${id}/json`);
+
+	return result.data;
+}
+
+export async function getServerMismatch(axios: AxiosInstance, id: string): Promise<string[]> {
+	const result = await axios.get(`/servers/${id}/mismatch`);
 
 	return result.data;
 }


### PR DESCRIPTION
Add support for showing gamemode information when available, displayed after mode separated by a slash. This provides more detailed game mode information to users.