### PR TITLE
style(servers): remove redundant h-full class from dashboard container

### DIFF
--- a/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
@@ -103,7 +103,7 @@ export default async function Page({ params }: Props) {
 
 	return (
 		<ScrollContainer className="flex p-2 flex-col gap-2 h-full">
-			<div className="flex flex-col gap-2 w-full h-full">
+			<div className="flex flex-col gap-2 w-full">
 				<div className="flex flex-col gap-2 p-2 w-full rounded-md border bg-card">
 					<header className="flex gap-2 items-center relative">
 						{avatar && <Image className="size-16 object-cover rounded-md" src={avatar} width={64} height={64} alt={name} />}

--- a/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
@@ -115,7 +115,7 @@ export default async function Page({ params }: Props) {
 							</span>
 						</div>
 						<div className="absolute top-1 right-1 p-2 backdrop-brightness-50 backdrop-blur-sm">
-							<InternalLink href="/setting">
+							<InternalLink href="setting">
 								<CogIcon className="size-4" />
 							</InternalLink>
 						</div>
@@ -222,8 +222,9 @@ export default async function Page({ params }: Props) {
 						{status === 'HOST' && (
 							<div className="flex min-w-[30vw] h-auto w-full rounded-md overflow-hidden">
 								<Image
-									className="object-contain overflow-hidden w-full h-auto rounded-md border"
 									key={status}
+									id="server-map-preview"
+									className="object-contain overflow-hidden w-full h-auto rounded-md border"
 									src={`${env.url.api}/servers/${id}/image`}
 									alt={name}
 									width={500}


### PR DESCRIPTION
The h-full class was unnecessary as the parent ScrollContainer already provides full height. This change improves code clarity by removing redundant styling.