### PR TITLE
fix: handle empty color syntax and adjust layout classes

### DIFF
--- a/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
@@ -1,4 +1,3 @@
-import { CogIcon } from 'lucide-react';
 import { Metadata } from 'next';
 import dynamic from 'next/dynamic';
 import Image from 'next/image';
@@ -11,7 +10,6 @@ import CopyButton from '@/components/button/copy.button';
 import { CatchError } from '@/components/common/catch-error';
 import ColorText from '@/components/common/color-text';
 import ErrorScreen from '@/components/common/error-screen';
-import InternalLink from '@/components/common/internal-link';
 import ScrollContainer from '@/components/common/scroll-container';
 import Tran from '@/components/common/tran';
 import RamUsageChart from '@/components/metric/ram-usage-chart';
@@ -113,11 +111,6 @@ export default async function Page({ params }: Props) {
 								<Tran text="server.owner" />
 								<IdUserCard id={userId} />
 							</span>
-						</div>
-						<div className="absolute top-1 right-1 p-2 backdrop-brightness-50 backdrop-blur-sm">
-							<InternalLink href="setting">
-								<CogIcon className="size-4" />
-							</InternalLink>
 						</div>
 					</header>
 					<main className="flex flex-wrap sm:gap-x-40 gap-x-20 gap-y-8 text-sm font-medium capitalize">

--- a/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/page.tsx
@@ -234,7 +234,7 @@ export default async function Page({ params }: Props) {
 						)}
 					</div>
 					<CatchError>
-						<div className="flex flex-col gap-2 grow-0 md:max-h-[calc(100vw-350px-var(--nav)+180px+40px)]">
+						<div className="flex flex-col gap-2 grow-0 md:max-h-[calc(100vw-350px-var(--nav)+180px+40px)] max-h-screen">
 							<ProtectedElement session={session} filter={canAccess}>
 								{status === 'HOST' && players > 0 && (
 									<div className="flex flex-col rounded-md border bg-card">

--- a/app/[locale]/(main)/servers/[id]/layout.tsx
+++ b/app/[locale]/(main)/servers/[id]/layout.tsx
@@ -4,14 +4,13 @@ import {
 	BarChart4,
 	FileIcon,
 	HardDriveIcon,
-	HistoryIcon,
 	LayoutDashboardIcon,
 	MapIcon,
 	PlugIcon,
 	SettingsIcon,
 	TerminalIcon,
 } from 'lucide-react';
-import { useParams } from 'next/navigation';
+import { useParams, usePathname } from 'next/navigation';
 import React, { ReactNode, use, useMemo } from 'react';
 
 import { CatchError } from '@/components/common/catch-error';
@@ -27,6 +26,7 @@ import useClientApi from '@/hooks/use-client';
 import useServer from '@/hooks/use-server';
 import useServerPlugins from '@/hooks/use-server-plugins';
 import ProtectedElement from '@/layout/protected-element';
+import ProtectedRoute from '@/layout/protected-route';
 import { Filter } from '@/lib/utils';
 
 import { useQuery } from '@tanstack/react-query';
@@ -72,7 +72,7 @@ export default function ServerLayout({ params, children }: LayoutProps) {
 	const { id } = use(params);
 	const { session } = useSession();
 	const { data: server, isError, error } = useServer(id);
-
+	const pathname = usePathname();
 	const ownerId = server?.userId;
 
 	const links: {
@@ -146,6 +146,8 @@ export default function ServerLayout({ params, children }: LayoutProps) {
 		return <ErrorMessage error={error} />;
 	}
 
+	const filter = links.find((link) => pathname.endsWith(link.href))?.filter;
+
 	return (
 		<div className="grid h-full grid-flow-row grid-rows-[48px_1fr] overflow-hidden">
 			<NavLinkProvider>
@@ -158,7 +160,9 @@ export default function ServerLayout({ params, children }: LayoutProps) {
 				</NavLinkContainer>
 			</NavLinkProvider>
 			<div className="flex overflow-hidden flex-col w-full h-full" key="child">
-				<CatchError>{children}</CatchError>
+				<CatchError>
+					<ProtectedRoute filter={filter}>{children}</ProtectedRoute>
+				</CatchError>
 			</div>
 		</div>
 	);

--- a/components/common/color-text.tsx
+++ b/components/common/color-text.tsx
@@ -70,7 +70,10 @@ export default function ColorText({ text, className }: ColorTextProps) {
 
 					// Reset color syntax
 					case '[]':
-						return '';
+						return null;
+
+					case '':
+						return null;
 
 					default: {
 						const style = {

--- a/components/common/color-text.tsx
+++ b/components/common/color-text.tsx
@@ -1,8 +1,12 @@
 import React, { useMemo } from 'react';
 
+
+
 import { colours } from '@/constant/constant';
 
-const COLOR_REGEX = /(\[[#]*[a-fA-F0-9]*\]|\[[#]*[a-zA-Z]*\]|\[[0-9;]*[0-9]+m[0-9]*)/gim;
+
+// eslint-disable-next-line no-control-regex
+const COLOR_REGEX = /(\[[#]*[a-fA-F0-9]*\]|\[[#]*[a-zA-Z]*\]|\u001B\[[0-9;]*m)/gim;
 
 const ANSI: Record<string, Format> = {
 	//ANSI color codes
@@ -202,7 +206,7 @@ function resolveColorAndFormat(color: string): ColorAndFormat {
 	} else {
 		color = color.substring(color.indexOf('['));
 
-		const keys = color.replaceAll('m', ' ').replace('[', '').split(' ').filter(Boolean);
+		const keys = color.replaceAll('m', ' ').replace('\u001B[', '').split(' ').filter(Boolean);
 
 		return {
 			color,

--- a/components/messages/message-card.tsx
+++ b/components/messages/message-card.tsx
@@ -47,7 +47,7 @@ export function MessageCard({ className, message }: Props) {
 						{contents.map(({ text, createdAt }, index) => (
 							<Tooltip key={index}>
 								<TooltipTrigger className="flex justify-start items-start p-0 cursor-default pointer-events-auto select-text text-start w-fit">
-									<ColorText className="overflow-hidden text-base break-words" text={text} />
+									<ColorText className="overflow-hidden break-words" text={text} />
 								</TooltipTrigger>
 								<TooltipContent>{new Date(createdAt).toLocaleString()}</TooltipContent>
 							</Tooltip>

--- a/components/server/server-card.skeleton.tsx
+++ b/components/server/server-card.skeleton.tsx
@@ -1,5 +1,5 @@
 import { Skeleton } from '@/components/ui/skeleton';
 
 export default function ServerCardSkeleton() {
-  return <Skeleton className="flex h-60 w-full rounded-md bg-card border" />;
+  return <Skeleton className="flex h-72 w-full rounded-md bg-card border" />;
 }

--- a/components/server/server-card.tsx
+++ b/components/server/server-card.tsx
@@ -9,16 +9,16 @@ import ServerStatusBadge from '@/components/server/server-status-badge';
 import { cn } from '@/lib/utils';
 import { ServerDto } from '@/types/response/ServerDto';
 
-type MyServerInstancesCardProps = {
+type ServerCardProps = {
 	server: ServerDto;
 };
 
 export default function ServerCard({
 	server: { id, name, players, port, status, mapName, mode, gamemode, isOfficial, avatar },
-}: MyServerInstancesCardProps) {
+}: ServerCardProps) {
 	return (
 		<InternalLink
-			className="flex flex-1 cursor-pointer flex-col gap-2 rounded-md bg-card p-4 h-60 relative border"
+			className="flex flex-1 cursor-pointer flex-col gap-2 rounded-md bg-card p-4 h-72 relative border"
 			href={`/servers/${id}`}
 		>
 			<Suspense>
@@ -45,7 +45,7 @@ export default function ServerCard({
 					<div className="flex flex-col gap-0.5">
 						<Tran asChild text="server.game-mode" />
 						<span>
-							<span>{mode}</span>
+							<span className="capitalize">{mode.toLowerCase()}</span>
 							{gamemode && '/'}
 							{gamemode && <span>{gamemode}</span>}
 						</span>


### PR DESCRIPTION
- Return null for empty color syntax cases in ColorText component to prevent rendering empty strings
- Add max-h-screen class to server dashboard layout for better responsive behavior
- Remove redundant text-base class from message card text styling