### PR TITLE
refactor(translation): simplify diff table edit state handling

### DIFF
--- a/app/[locale]/(main)/translation/diff-table.tsx
+++ b/app/[locale]/(main)/translation/diff-table.tsx
@@ -78,7 +78,6 @@ function DiffCard({ translation, language }: DiffCardProps) {
 	const [currentValue, setCurrentValue] = useState('');
 
 	const axios = useClientApi();
-	const [isEdit, setEdit] = useState(false);
 	const { mutate, status } = useMutation({
 		mutationFn: (payload: CreateTranslationRequest) => createTranslation(axios, payload),
 		onError: (error) => toast.error(<Tran text="upload.fail" />, { error }),
@@ -111,21 +110,16 @@ function DiffCard({ translation, language }: DiffCardProps) {
 				</div>
 			</TableCell>
 			<TableCell>
-				<div className="flex items-center gap-2" onClick={() => setEdit(true)}>
-					{isEdit ? ( //
-						<Textarea
-							className="border-transparent p-0 outline-none ring-0 focus-visible:outline-none focus-visible:ring-0"
-							placeholder={currentValue ?? key}
-							defaultValue={currentValue ?? key}
-							onChange={(event) => setCurrentValue(event.target.value)}
-							onBlur={() => {
-								setEdit(false);
-								create();
-							}}
-						/>
-					) : (
-						<HighLightTranslation text={currentValue ?? key} />
-					)}
+				<div className="flex items-center gap-2">
+					<Textarea
+						className="border-transparent p-0 outline-none ring-0 focus-visible:outline-none focus-visible:ring-0"
+						placeholder={currentValue ?? key}
+						defaultValue={currentValue ?? key}
+						onChange={(event) => setCurrentValue(event.target.value)}
+						onBlur={() => {
+							create();
+						}}
+					/>
 					<TranslationStatus status={status} />
 				</div>
 			</TableCell>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -126,7 +126,7 @@ module.exports = {
 				'slide-in': 'slide-in 0.5s forwards',
 				popup: 'popup 0.2s forwards',
 				spin: 'spin 1s linear infinite',
-				appear: 'appear 0.5s linear',
+				appear: 'appear 0.2s linear',
 				expand: 'expand 1s linear forwards',
 				collapse: 'collapse 1s linear forwards',
 			},


### PR DESCRIPTION
Remove redundant isEdit state and always show Textarea component to streamline the translation editing flow. This eliminates the toggle behavior and makes the interface more straightforward for users.