### PR TITLE
feat(servers): add discord channel id field to server settings

### DIFF
--- a/app/[locale]/(main)/servers/[id]/setting/server-update-form.tsx
+++ b/app/[locale]/(main)/servers/[id]/setting/server-update-form.tsx
@@ -219,6 +219,24 @@ export default function ServerUpdateForm({ server }: Props) {
 				/>
 				<FormField
 					control={form.control}
+					name="discordChannelId"
+					render={({ field }) => (
+						<FormItem className="grid">
+							<FormLabel>
+								<Tran text="server.discord-channel-id" />
+							</FormLabel>
+							<FormControl>
+								<Input {...field} value={field.value ?? ''} />
+							</FormControl>
+							<FormDescription>
+								<Tran text="server.discord-channel-id-description" />
+							</FormDescription>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+				<FormField
+					control={form.control}
 					name="avatar"
 					render={({ field }) => (
 						<FormItem className="grid">

--- a/types/request/UpdateServerRequest.ts
+++ b/types/request/UpdateServerRequest.ts
@@ -11,6 +11,7 @@ export const PutServerSchema = z.object({
 	gamemode: z.string().max(100).optional().nullable(),
 	hostCommand: z.string().max(1000).optional().nullable(),
 	webhook: z.string().max(1000).optional().nullable(),
+	discordChannelId: z.string().max(100).optional().nullable(),
 	avatar: z.string().max(1000).optional().nullable(),
 	image: z.string().max(1000),
 });

--- a/types/response/Server.ts
+++ b/types/response/Server.ts
@@ -14,6 +14,7 @@ export default interface Server {
 	hostCommand: string | null;
 	address: string;
 	image: string;
+	discordChannelId: string | null;
 	avatar: string;
 	webhook: string | null;
 	isAutoTurnOff: boolean;

--- a/types/response/ServerDto.ts
+++ b/types/response/ServerDto.ts
@@ -18,6 +18,7 @@ export type ServerDto = {
 	mapName: string;
 	address: string;
 	avatar: string;
+	discordChannelId: string | null;
 	isAutoTurnOff: boolean;
 	isHub: boolean;
 	isPaused: boolean;


### PR DESCRIPTION
Add optional discordChannelId field to server update schema and form to allow linking servers to Discord channels. This enables better Discord integration for server notifications and updates.