### PR TITLE
style(server-update-form): remove redundant h-full class from form

### DIFF
--- a/app/[locale]/(main)/servers/[id]/setting/server-update-form.tsx
+++ b/app/[locale]/(main)/servers/[id]/setting/server-update-form.tsx
@@ -63,7 +63,7 @@ export default function ServerUpdateForm({ server }: Props) {
 	return (
 		<Form {...form}>
 			<form
-				className="flex space-y-4 flex-col justify-between p-4 h-full relative bg-card rounded-md"
+				className="flex space-y-4 flex-col justify-between p-4 relative bg-card rounded-md"
 				onSubmit={form.handleSubmit((value) => mutate(value))}
 			>
 				<FormField


### PR DESCRIPTION
The h-full class was unnecessary as the form's height is already properly constrained by its parent container. This change improves code clarity by removing redundant styling.