### PR TITLE
refactor(scroll-container): simplify scroll container implementation

### DIFF
--- a/app/[locale]/(main)/logs/static-log.tsx
+++ b/app/[locale]/(main)/logs/static-log.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { FilterIcon, XIcon } from 'lucide-react';
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import ComboBox from '@/components/common/combo-box';
 import GridPaginationList from '@/components/common/grid-pagination-list';
@@ -39,8 +39,6 @@ const defaultFilter: Omit<LogPaginationQueryType, 'page' | 'size'> = {
 export default function StaticLog() {
 	const [filter, _setFilter] = useState<Omit<LogPaginationQueryType, 'page' | 'size'>>(defaultFilter);
 	const { env, ip, userId, url, content, before, after, collection } = filter;
-
-	const container = useRef<HTMLDivElement | null>(null);
 
 	const setFilter = useCallback(
 		(value: Partial<Omit<LogPaginationQueryType, 'page' | 'size'>>) => _setFilter((prev) => ({ ...prev, ...value })),
@@ -83,7 +81,7 @@ export default function StaticLog() {
 				</div>
 				<PaginationLayoutSwitcher />
 			</div>
-			<ScrollContainer className="relative flex h-full flex-col gap-2" ref={container}>
+			<ScrollContainer className="relative flex h-full flex-col gap-2">
 				<ListLayout>
 					<InfinitePage<Log, typeof LogPaginationQuerySchema>
 						className="flex w-full flex-col items-center justify-center gap-2"

--- a/components/common/message-list.tsx
+++ b/components/common/message-list.tsx
@@ -2,7 +2,6 @@ import React, { ReactNode, useCallback, useEffect, useMemo, useRef, useState } f
 import { useLocalStorage } from 'usehooks-ts';
 
 import NoResult from '@/components/common/no-result';
-import ScrollContainer from '@/components/common/scroll-container';
 
 import { useSocket } from '@/context/socket.context';
 import useMessageQuery from '@/hooks/use-message-query';
@@ -216,13 +215,13 @@ export default function MessageList({
 	}
 
 	return (
-		<ScrollContainer id={queryKey.join('_')} className={cn('flex h-full w-full overflow-x-hidden', className)} ref={container}>
+		<div className={cn('flex h-full w-full overflow-x-hidden', className)} ref={container}>
 			<section className="h-fit w-full" ref={(ref) => setList(ref)}>
 				{!hasNextPage && end}
 				{isFetching && loader}
 				{pages}
 				{isError && <ErrorMessage error={error} />}
 			</section>
-		</ScrollContainer>
+		</div>
 	);
 }

--- a/components/common/scroll-container.tsx
+++ b/components/common/scroll-container.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
-import React, { ReactNode, forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef } from 'react';
+import React, { ReactNode, useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { cn } from '@/lib/utils';
 
@@ -11,12 +11,10 @@ type Props = {
 	children: ReactNode;
 } & React.ComponentPropsWithoutRef<'div'>;
 
-const ScrollContainer = forwardRef<HTMLDivElement, Props>(({ className, id, children }, forwardedRef) => {
+export default function ScrollContainer({ className, id, children, ...rest }: Props) {
 	const pathname = usePathname();
 	const innerRef = useRef<HTMLDivElement>(null);
 	const scrollKey = useMemo(() => `scroll-top${pathname}-${id}`.replaceAll('/', '-'), [id, pathname]);
-
-	useImperativeHandle(forwardedRef, () => innerRef.current!, []);
 
 	useEffect(() => {
 		try {
@@ -38,12 +36,13 @@ const ScrollContainer = forwardRef<HTMLDivElement, Props>(({ className, id, chil
 	);
 
 	return (
-		<div ref={innerRef} className={cn('h-fit scroll-container overflow-y-auto w-full', className)} onScroll={handleScroll}>
+		<div
+			{...rest}
+			ref={innerRef}
+			className={cn('h-fit scroll-container overflow-y-auto w-full', className)}
+			onScroll={handleScroll}
+		>
 			{children}
 		</div>
 	);
-});
-
-ScrollContainer.displayName = 'ScrollContainer';
-
-export default ScrollContainer;
+}

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,47 +1,82 @@
 import * as React from 'react';
 
-import ScrollContainer from '@/components/common/scroll-container';
-
 import { cn } from '@/lib/utils';
 
 const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(({ className, ...props }, ref) => {
-  return (
-    <ScrollContainer ref={ref}>
-      <table className={cn('w-full caption-bottom text-sm', className)} {...props} />
-    </ScrollContainer>
-  );
+	return (
+		<div className={cn('h-fit scroll-container overflow-y-auto w-full', className)} ref={ref}>
+			<table className={cn('w-full caption-bottom text-sm', className)} {...props} />
+		</div>
+	);
 });
 Table.displayName = 'Table';
 
-const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(({ className, ...props }, ref) => (
-  <thead ref={ref} className={cn('sticky top-0 bg-background [&_tr]:border-b border-border', className)} {...props} />
-));
+const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+	({ className, ...props }, ref) => (
+		<thead ref={ref} className={cn('sticky top-0 bg-background [&_tr]:border-b border-border', className)} {...props} />
+	),
+);
 TableHeader.displayName = 'TableHeader';
 
-const TableBody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(({ className, ...props }, ref) => <tbody ref={ref} className={cn('[&_tr:last-child]:border-0 border-border', className)} {...props} />);
+const TableBody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+	({ className, ...props }, ref) => (
+		<tbody ref={ref} className={cn('[&_tr:last-child]:border-0 border-border', className)} {...props} />
+	),
+);
 TableBody.displayName = 'TableBody';
 
-const TableFooter = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(({ className, ...props }, ref) => (
-  <tfoot ref={ref} className={cn('border-t bg-muted/50 font-medium [&>tr]:last:border-b-0 border-border', className)} {...props} />
-));
+const TableFooter = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+	({ className, ...props }, ref) => (
+		<tfoot
+			ref={ref}
+			className={cn('border-t bg-muted/50 font-medium [&>tr]:last:border-b-0 border-border', className)}
+			{...props}
+		/>
+	),
+);
 TableFooter.displayName = 'TableFooter';
 
-const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(({ className, ...props }, ref) => (
-  <tr ref={ref} className={cn('border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted border-border', className)} {...props} />
-));
+const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+	({ className, ...props }, ref) => (
+		<tr
+			ref={ref}
+			className={cn('border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted border-border', className)}
+			{...props}
+		/>
+	),
+);
 TableRow.displayName = 'TableRow';
 
-const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<HTMLTableCellElement>>(({ className, ...props }, ref) => (
-  <th ref={ref} className={cn('h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]', className)} {...props} />
-));
+const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<HTMLTableCellElement>>(
+	({ className, ...props }, ref) => (
+		<th
+			ref={ref}
+			className={cn(
+				'h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+				className,
+			)}
+			{...props}
+		/>
+	),
+);
 TableHead.displayName = 'TableHead';
 
-const TableCell = React.forwardRef<HTMLTableCellElement, React.TdHTMLAttributes<HTMLTableCellElement>>(({ className, ...props }, ref) => (
-  <td ref={ref} className={cn('p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]', className)} {...props} />
-));
+const TableCell = React.forwardRef<HTMLTableCellElement, React.TdHTMLAttributes<HTMLTableCellElement>>(
+	({ className, ...props }, ref) => (
+		<td
+			ref={ref}
+			className={cn('p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]', className)}
+			{...props}
+		/>
+	),
+);
 TableCell.displayName = 'TableCell';
 
-const TableCaption = React.forwardRef<HTMLTableCaptionElement, React.HTMLAttributes<HTMLTableCaptionElement>>(({ className, ...props }, ref) => <caption ref={ref} className={cn('mt-4 text-sm text-muted-foreground', className)} {...props} />);
+const TableCaption = React.forwardRef<HTMLTableCaptionElement, React.HTMLAttributes<HTMLTableCaptionElement>>(
+	({ className, ...props }, ref) => (
+		<caption ref={ref} className={cn('mt-4 text-sm text-muted-foreground', className)} {...props} />
+	),
+);
 TableCaption.displayName = 'TableCaption';
 
 export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };


### PR DESCRIPTION
- Remove forwardRef and useImperativeHandle as they were not necessary
- Replace ScrollContainer with div in message-list and table components
- Maintain scroll position persistence functionality