### PR TITLE
feat(logs): add image support for log type 11 and remove filter click

### DIFF
--- a/app/[locale]/(main)/logs/static-log.tsx
+++ b/app/[locale]/(main)/logs/static-log.tsx
@@ -99,7 +99,7 @@ export default function StaticLog() {
 						queryKey={['logs']}
 						queryFn={getLogs}
 					>
-						{(page) => page.map((data) => <LogCard key={data.id} log={data} onClick={setFilter} />)}
+						{(page) => page.map((data) => <LogCard key={data.id} log={data} />)}
 					</InfinitePage>
 				</ListLayout>
 				<GridLayout>
@@ -119,7 +119,7 @@ export default function StaticLog() {
 						queryKey={['logs']}
 						queryFn={getLogs}
 					>
-						{(page) => page.map((data) => <LogCard key={data.id} log={data} onClick={setFilter} />)}
+						{(page) => page.map((data) => <LogCard key={data.id} log={data} />)}
 					</GridPaginationList>
 				</GridLayout>
 			</ScrollContainer>

--- a/components/log/log-card.tsx
+++ b/components/log/log-card.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import React from 'react';
 
 import IdUserCard from '@/components/user/id-user-card';
@@ -5,28 +6,31 @@ import IdUserCard from '@/components/user/id-user-card';
 import { Log } from '@/types/Log';
 
 type LogCardProps = {
-  log: Log;
-  onClick: (data: { ip?: string; userId?: string; url?: string; content?: string }) => void;
+	log: Log;
 };
 
-export default function LogCard({ log: { requestUrl, ip, userId, content, createdAt, environment }, onClick }: LogCardProps) {
-  return (
-    <div className="flex w-full flex-col break-words rounded-md bg-card p-2 text-xs h-full">
-      {userId && (
-        <span onClick={() => onClick({ userId })}>
-          <IdUserCard id={userId} />
-        </span>
-      )}
-      {requestUrl && <span onClick={() => onClick({ url: requestUrl })}>URL: {requestUrl}</span>}
-      <span onClick={() => onClick({ ip })}>IP: {ip}</span>
-      Env: {environment === 1 ? 'Prod' : 'Dev'}
-      <div onClick={() => onClick({ content })}>
-        Content:
-        {content.split('\n').map((item, index) => (
-          <span key={index}>{item}</span>
-        ))}
-      </div>
-      <span>Created at: {new Date(createdAt).toLocaleString()}</span>
-    </div>
-  );
+export default function LogCard({ log: { requestUrl, ip, userId, content, createdAt, environment, type } }: LogCardProps) {
+	return (
+		<div className="flex w-full flex-col break-words rounded-md bg-card p-2 text-xs h-full">
+			{userId && (
+				<span>
+					<IdUserCard id={userId} />
+				</span>
+			)}
+			{requestUrl && <span>URL: {requestUrl}</span>}
+			<span>IP: {ip}</span>
+			Env: {environment === 1 ? 'Prod' : 'Dev'}
+			{type === 11 ? (
+				<Image className="size-16" src={content} width={64} height={64} alt={content} />
+			) : (
+				<div>
+					Content:
+					{content.split('\n').map((item, index) => (
+						<span key={index}>{item}</span>
+					))}
+				</div>
+			)}
+			<span>Created at: {new Date(createdAt).toLocaleString()}</span>
+		</div>
+	);
 }

--- a/types/Log.ts
+++ b/types/Log.ts
@@ -1,9 +1,10 @@
 export type Log = {
-  id: string;
-  content: string;
-  environment: number;
-  createdAt: number;
-  requestUrl: string;
-  ip: string;
-  userId: string;
+	id: string;
+	content: string;
+	environment: number;
+	createdAt: number;
+	requestUrl: string;
+	ip: string;
+	userId: string;
+	type: number;
 };


### PR DESCRIPTION
- Add `type` field to Log type definition
- Remove onClick filter functionality from LogCard and its usages
- Display images when log type is 11 instead of text content