### PR TITLE
refactor(components): move border-b styling from DetailTitle to usage…

### DIFF
--- a/app/[locale]/(main)/servers/[id]/setting/server-update-form.tsx
+++ b/app/[locale]/(main)/servers/[id]/setting/server-update-form.tsx
@@ -7,6 +7,7 @@ import { useForm } from 'react-hook-form';
 import ColorText from '@/components/common/color-text';
 import ComboBox from '@/components/common/combo-box';
 import ImageUploader from '@/components/common/image-uploader';
+import InputWithAutoComplete from '@/components/common/input-with-autocomplete';
 import Tran from '@/components/common/tran';
 import { Button } from '@/components/ui/button';
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
@@ -158,20 +159,12 @@ export default function ServerUpdateForm({ server }: Props) {
 								<Tran text="server.image" />
 							</FormLabel>
 							<FormControl>
-								<ComboBox
+								<InputWithAutoComplete
+									{...field}
 									className={cn('w-full lowercase', {
 										'border-destructive': fieldState.invalid,
 									})}
-									searchBar={false}
-									value={{ label: field.value, value: field.value }}
-									values={
-										images?.map((value) => ({
-											label: value,
-											value,
-										})) ?? []
-									}
-									required
-									onChange={(value) => field.onChange(value)}
+									values={images ?? []}
 								/>
 							</FormControl>
 							<FormDescription>

--- a/components/common/detail.tsx
+++ b/components/common/detail.tsx
@@ -57,7 +57,7 @@ type TitleProps = Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> & {
 
 export function DetailTitle({ className, children }: TitleProps) {
 	return (
-		<h1 className={cn('text-xl capitalize border-b', className)}>
+		<h1 className={cn('text-xl capitalize', className)}>
 			<ColorText text={children} />
 		</h1>
 	);

--- a/components/common/input-with-autocomplete.tsx
+++ b/components/common/input-with-autocomplete.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { debounce } from 'throttle-debounce';
+
+import { Input } from '@/components/ui/input';
+
+import { cn } from '@/lib/utils';
+
+type InputWithAutoCompleteProps = {
+	className?: string;
+	value: string;
+	values: string[];
+	onChange: (value: string) => void;
+};
+
+export default function InputWithAutoComplete({ className, value, values, onChange }: InputWithAutoCompleteProps) {
+	const [open, setOpen] = useState(false);
+	const close = debounce(200, () => setOpen(false));
+
+	return (
+		<div className="relative">
+			<Input
+				onFocus={() => setOpen(true)}
+				onBlur={close}
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+				className={cn(className)}
+			/>
+
+			<section
+				className={cn('absolute mt-2 bg-secondary w-full border divide-y rounded-lg hidden overflow-hidden max-h-[50dh]', {
+					block: open,
+				})}
+			>
+				{values
+					.filter((key) => key.includes(value))
+					.map((key) => (
+						<button
+							className="cursor-pointer hover:bg-brand w-full text-start p-2"
+							key={key}
+							type="button"
+							onClick={() => {
+								onChange(key);
+								close();
+							}}
+						>
+							{key}
+						</button>
+					))}
+			</section>
+		</div>
+	);
+}

--- a/components/log/log-card.tsx
+++ b/components/log/log-card.tsx
@@ -21,7 +21,7 @@ export default function LogCard({ log: { requestUrl, ip, userId, content, create
 			<span>IP: {ip}</span>
 			Env: {environment === 1 ? 'Prod' : 'Dev'}
 			{type === 11 ? (
-				<Image className="size-16" src={content} width={64} height={64} alt={content} />
+				<Image className="size-64 rounded-md overflow-hidden" src={content} width={256} height={256} alt={content} />
 			) : (
 				<div>
 					Content:

--- a/components/map/map-detail-card.tsx
+++ b/components/map/map-detail-card.tsx
@@ -79,7 +79,7 @@ export default function MapDetailCard({
 				<DetailContent>
 					<DetailImage src={imageUrl} errorSrc={errorImageUrl} alt={name} />
 					<DetailHeader>
-						<DetailTitle>{name}</DetailTitle>
+						<DetailTitle className="border-b">{name}</DetailTitle>
 						<Tabs defaultValue="info" className="overflow-hidden flex flex-col">
 							<TabsList className="grid w-full grid-cols-3">
 								<TabsTrigger value="info">

--- a/components/map/upload-map-detail-card.tsx
+++ b/components/map/upload-map-detail-card.tsx
@@ -57,7 +57,7 @@ export default function UploadMapDetailCard({
 			<DetailContent>
 				<DetailImage src={imageUrl} errorSrc={errorImageUrl} alt={name} />
 				<DetailHeader>
-					<DetailTitle>{name}</DetailTitle>
+					<DetailTitle className="border-b">{name}</DetailTitle>
 					<Tabs defaultValue="info" className="flex overflow-hidden flex-col">
 						<TabsList className="grid grid-cols-3 w-full">
 							<TabsTrigger value="info">

--- a/components/schematic/schematic-detail-card.tsx
+++ b/components/schematic/schematic-detail-card.tsx
@@ -90,7 +90,7 @@ export default function SchematicDetailCard({
 				<DetailContent>
 					<DetailImage src={imageUrl} errorSrc={errorImageUrl} alt={name} />
 					<DetailHeader>
-						<DetailTitle>{name}</DetailTitle>
+						<DetailTitle className="border-b">{name}</DetailTitle>
 						<Tabs defaultValue="info" className="overflow-hidden flex flex-col">
 							<TabsList className="grid w-full grid-cols-2">
 								<TabsTrigger value="info">

--- a/components/schematic/upload-schematic-detail-card.tsx
+++ b/components/schematic/upload-schematic-detail-card.tsx
@@ -81,7 +81,7 @@ export default function UploadSchematicDetailCard({
 			<DetailContent>
 				<DetailImage src={imageUrl} errorSrc={errorImageUrl} alt={name} />
 				<DetailHeader>
-					<DetailTitle>{name}</DetailTitle>
+					<DetailTitle className="border-b">{name}</DetailTitle>
 					<Tabs defaultValue="info" className="overflow-hidden flex flex-col">
 						<TabsList className="grid w-full grid-cols-2">
 							<TabsTrigger value="info">


### PR DESCRIPTION
… sites

The border-bottom styling was removed from the base DetailTitle component and explicitly added to the specific usage sites where it's needed. This makes the component more flexible and allows for better control over styling in different contexts.