### PR TITLE
refactor(stats): remove redundant charts and headers from stats page

### DIFF
--- a/action/common.ts
+++ b/action/common.ts
@@ -10,6 +10,7 @@ import { z } from 'zod';
 import { DEFAULT_PAGINATION_SIZE, PAGINATION_SIZE_PERSISTENT_KEY } from '@/constant/constant';
 import { ApiError } from '@/lib/error';
 import axiosInstance from '@/query/config/config';
+import { getUser } from '@/query/user';
 import { Session } from '@/types/response/Session';
 import { QuerySchema } from '@/types/schema/search-query';
 
@@ -70,6 +71,9 @@ export async function serverApi<T>(queryFn: ServerApi<T>): Promise<T | ApiError>
 	});
 }
 
+export const getCachedUser = async (id: string) =>
+	unstable_cache(() => catchError(axiosInstance, (axios) => getUser(axios, { id })));
+
 const getCachedSession: (cookie: string) => Promise<Session | null | ApiError> = cache(
 	unstable_cache(
 		async (cookie: string) => {
@@ -104,8 +108,6 @@ export async function getAuthSession() {
 
 	return session;
 }
-
-
 
 export const getServerApi = async (): Promise<AxiosInstance> => {
 	const cookie = await cookies();

--- a/app/[locale]/(main)/maps/[id]/page.tsx
+++ b/app/[locale]/(main)/maps/[id]/page.tsx
@@ -4,7 +4,7 @@ import React, { cache } from 'react';
 import ErrorScreen from '@/components/common/error-screen';
 import MapDetailCard from '@/components/map/map-detail-card';
 
-import { serverApi } from '@/action/common';
+import { getCachedUser, serverApi } from '@/action/common';
 import env from '@/constant/env';
 import { Locale } from '@/i18n/config';
 import { getTranslation } from '@/i18n/server';
@@ -12,7 +12,6 @@ import { getErrorMessage, isError } from '@/lib/error';
 import { generateAlternate } from '@/lib/i18n.utils';
 import { formatTitle } from '@/lib/utils';
 import { getMap } from '@/query/map';
-import { getUser } from '@/query/user';
 
 type Props = {
 	params: Promise<{ id: string; locale: Locale }>;
@@ -23,14 +22,16 @@ const getCachedMap = cache((id: string) => serverApi((axios) => getMap(axios, { 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
 	const { id, locale } = await params;
 	const { t } = await getTranslation(locale, ['tags']);
+
 	const map = await getCachedMap(id);
+
 	if (isError(map)) {
 		return { title: 'Error' };
 	}
 
 	const { name, description, downloadCount, likes, dislikes, userId, tags, createdAt } = map;
 
-	const user = await serverApi((axios) => getUser(axios, { id: userId }));
+	const user = await getCachedUser(userId);
 
 	if (isError(user)) {
 		return { title: 'Error', description: getErrorMessage(user) };

--- a/app/[locale]/(main)/schematics/[id]/page.tsx
+++ b/app/[locale]/(main)/schematics/[id]/page.tsx
@@ -4,7 +4,7 @@ import React, { cache } from 'react';
 import ErrorScreen from '@/components/common/error-screen';
 import SchematicDetailCard from '@/components/schematic/schematic-detail-card';
 
-import { serverApi } from '@/action/common';
+import { getCachedUser, serverApi } from '@/action/common';
 import env from '@/constant/env';
 import { Locale } from '@/i18n/config';
 import { getTranslation } from '@/i18n/server';
@@ -12,7 +12,6 @@ import { getErrorMessage, isError } from '@/lib/error';
 import { generateAlternate } from '@/lib/i18n.utils';
 import { formatTitle } from '@/lib/utils';
 import { getSchematic } from '@/query/schematic';
-import { getUser } from '@/query/user';
 
 type Props = {
 	params: Promise<{ id: string; locale: Locale }>;
@@ -31,7 +30,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 	const { name, description, downloadCount, likes, dislikes, userId, tags, createdAt } = schematic;
 
-	const user = await serverApi((axios) => getUser(axios, { id: userId }));
+	const user = await getCachedUser(userId);
 
 	if (isError(user)) {
 		return { title: 'Error', description: getErrorMessage(user) };

--- a/app/[locale]/(main)/servers/[id]/stats/page.tsx
+++ b/app/[locale]/(main)/servers/[id]/stats/page.tsx
@@ -79,9 +79,6 @@ export default function Page({ params }: { params: Promise<{ id: string }> }) {
 			</div>
 			<Divider />
 			<ScrollContainer className="p-2 flex flex-col gap-2">
-				<h2 className="text-base font-semibold">
-					<Tran text="metric.live" asChild />
-				</h2>
 				<div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-2">
 					<Suspense>
 						<LineChart
@@ -121,34 +118,8 @@ export default function Page({ params }: { params: Promise<{ id: string }> }) {
 						/>
 					</Suspense>
 					<Suspense>
-						<LineChart
-							label="player"
-							metrics={
-								data?.map(({ createdAt, value }) => ({
-									createdAt: new Date(createdAt),
-									value: value.players,
-								})) ?? []
-							}
-						/>
+						<LoginLogChart serverId={id} filter={filter} />
 					</Suspense>
-					<Suspense>
-						<LineChart
-							label="kick"
-							metrics={
-								data?.map(({ createdAt, value }) => ({
-									createdAt: new Date(createdAt),
-									value: value.kicks,
-								})) ?? []
-							}
-						/>
-					</Suspense>
-				</div>
-				<Divider className="col-span-full" />
-				<h2 className="text-base font-semibold">
-					<Tran text="metric.static" asChild />
-				</h2>
-				<div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-2">
-					<LoginLogChart serverId={id} filter={filter} />
 				</div>
 			</ScrollContainer>
 		</div>


### PR DESCRIPTION
Simplify the stats page by removing duplicate player/kick charts and redundant section headers. The login log chart is now integrated into the main grid layout.