### PR TITLE
refactor(mismatch-panel): replace flex gap with space-x and p with span

### DIFF
--- a/app/[locale]/(main)/servers/[id]/(dashboard)/mismatch-panel.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/mismatch-panel.tsx
@@ -39,7 +39,7 @@ export default function MismatchPanel() {
 	return (
 		<Popover>
 			<PopoverTrigger asChild>
-				<div className="text-sm text-destructive-foreground overflow-hidden text-ellipsis flex gap-2">
+				<div className="text-sm text-destructive-foreground overflow-hidden text-ellipsis space-x-1">
 					<span>{data[0]}</span>
 					{data.length > 1 && <p>({data.length - 1}+)</p>}
 				</div>
@@ -52,9 +52,9 @@ export default function MismatchPanel() {
 					</Suspense>
 					<Divider />
 					{data.map((mismatch) => (
-						<p className="rounded-md text-destructive-foreground p-2 bg-destructive text-wrap wrap break-words" key={mismatch}>
+						<span className="rounded-md text-destructive-foreground p-2 bg-destructive text-wrap wrap break-words" key={mismatch}>
 							{mismatch}
-						</p>
+						</span>
 					))}
 				</section>
 			</PopoverContent>


### PR DESCRIPTION
Improve layout consistency by using Tailwind's space-x utility instead of flex gap. Replace p tags with span for better semantic HTML.