### PR TITLE
refactor: optimize data fetching and loading in map/schematic pages

### DIFF
--- a/action/query.ts
+++ b/action/query.ts
@@ -1,12 +1,20 @@
 import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
+import 'server-only';
 
 import { catchError, serverApi } from '@/action/common';
 import axiosInstance from '@/query/config/config';
-import { getSchematic } from '@/query/schematic';
+import { getMap, getMapUpload } from '@/query/map';
+import { getSchematic, getSchematicUpload } from '@/query/schematic';
 import { getUser } from '@/query/user';
-
-export const getCachedSchematic = cache((id: string) => serverApi((axios) => getSchematic(axios, { id })));
 
 export const getCachedUser = async (id: string) =>
 	unstable_cache(() => catchError(axiosInstance, (axios) => getUser(axios, { id })));
+
+export const getCachedSchematic = cache((id: string) => serverApi((axios) => getSchematic(axios, { id })));
+
+export const getCachedMap = cache((id: string) => serverApi((axios) => getMap(axios, { id })));
+
+export const getCachedSchematicUpload = cache((id: string) => serverApi((axios) => getSchematicUpload(axios, { id })));
+
+export const getCachedMapUpload = cache((id: string) => serverApi((axios) => getMapUpload(axios, { id })));

--- a/app/[locale]/(main)/admin/maps/[id]/loading.tsx
+++ b/app/[locale]/(main)/admin/maps/[id]/loading.tsx
@@ -1,5 +1,0 @@
-import DetailSkeleton from '@/components/skeleton/detail.skeleton';
-
-export default function Loading() {
-	return <DetailSkeleton />;
-}

--- a/app/[locale]/(main)/admin/maps/[id]/page.tsx
+++ b/app/[locale]/(main)/admin/maps/[id]/page.tsx
@@ -1,24 +1,21 @@
 import { Metadata } from 'next';
-import React, { cache } from 'react';
+import React from 'react';
 
 import ErrorScreen from '@/components/common/error-screen';
 import Tran from '@/components/common/tran';
 import UploadMapDetailCard from '@/components/map/upload-map-detail-card';
 import BackButton from '@/components/ui/back-button';
 
-import { serverApi } from '@/action/common';
+import { getCachedMapUpload } from '@/action/query';
 import env from '@/constant/env';
 import { Locale } from '@/i18n/config';
-import { formatTitle } from '@/lib/utils';
-import { getMapUpload } from '@/query/map';
 import { isError } from '@/lib/error';
 import { generateAlternate } from '@/lib/i18n.utils';
+import { formatTitle } from '@/lib/utils';
 
 type Props = {
 	params: Promise<{ id: string; locale: Locale }>;
 };
-
-const getCachedMapUpload = cache((id: string) => serverApi((axios) => getMapUpload(axios, { id })));
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
 	const { id } = await params;

--- a/app/[locale]/(main)/admin/schematics/[id]/loading.tsx
+++ b/app/[locale]/(main)/admin/schematics/[id]/loading.tsx
@@ -1,5 +1,0 @@
-import DetailSkeleton from '@/components/skeleton/detail.skeleton';
-
-export default function Loading() {
-	return <DetailSkeleton />;
-}

--- a/app/[locale]/(main)/admin/schematics/[id]/page.tsx
+++ b/app/[locale]/(main)/admin/schematics/[id]/page.tsx
@@ -1,24 +1,21 @@
 import { Metadata } from 'next/dist/types';
-import React, { cache } from 'react';
+import React from 'react';
 
 import ErrorScreen from '@/components/common/error-screen';
 import Tran from '@/components/common/tran';
 import UploadSchematicDetailCard from '@/components/schematic/upload-schematic-detail-card';
 import BackButton from '@/components/ui/back-button';
 
-import { serverApi } from '@/action/common';
+import { getCachedSchematicUpload } from '@/action/query';
 import env from '@/constant/env';
 import { Locale } from '@/i18n/config';
 import { isError } from '@/lib/error';
 import { generateAlternate } from '@/lib/i18n.utils';
 import { formatTitle } from '@/lib/utils';
-import { getSchematicUpload } from '@/query/schematic';
 
 type Props = {
 	params: Promise<{ id: string; locale: Locale }>;
 };
-
-const getCachedSchematicUpload = cache((id: string) => serverApi((axios) => getSchematicUpload(axios, { id })));
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
 	const { id } = await params;

--- a/app/[locale]/(main)/maps/[id]/loading.tsx
+++ b/app/[locale]/(main)/maps/[id]/loading.tsx
@@ -1,5 +1,0 @@
-import DetailSkeleton from '@/components/skeleton/detail.skeleton';
-
-export default function Loading() {
-	return <DetailSkeleton />;
-}

--- a/app/[locale]/(main)/maps/[id]/page.tsx
+++ b/app/[locale]/(main)/maps/[id]/page.tsx
@@ -1,24 +1,20 @@
 import { Metadata } from 'next/dist/types';
-import React, { cache } from 'react';
+import React, { Suspense } from 'react';
 
-import ErrorScreen from '@/components/common/error-screen';
 import MapDetailCard from '@/components/map/map-detail-card';
+import DetailSkeleton from '@/components/skeleton/detail.skeleton';
 
-import { serverApi } from '@/action/common';
+import { getCachedMap, getCachedUser } from '@/action/query';
 import env from '@/constant/env';
 import { Locale } from '@/i18n/config';
 import { getTranslation } from '@/i18n/server';
 import { getErrorMessage, isError } from '@/lib/error';
 import { generateAlternate } from '@/lib/i18n.utils';
 import { formatTitle } from '@/lib/utils';
-import { getMap } from '@/query/map';
-import { getCachedUser } from '@/action/query';
 
 type Props = {
 	params: Promise<{ id: string; locale: Locale }>;
 };
-
-const getCachedMap = cache((id: string) => serverApi((axios) => getMap(axios, { id })));
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
 	const { id, locale } = await params;
@@ -57,12 +53,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 }
 
 export default async function Page({ params }: Props) {
-	const { id } = await params;
-	const map = await getCachedMap(id);
+	const { id, locale } = await params;
 
-	if (isError(map)) {
-		return <ErrorScreen error={map} />;
-	}
-
-	return <MapDetailCard map={map} />;
+	return (
+		<Suspense fallback={<DetailSkeleton />}>
+			<MapDetailCard id={id} locale={locale} />
+		</Suspense>
+	);
 }

--- a/components/button/copy.button.tsx
+++ b/components/button/copy.button.tsx
@@ -6,7 +6,6 @@ import React, { ReactNode } from 'react';
 
 import Tran from '@/components/common/tran';
 import { ButtonProps } from '@/components/ui/button';
-import { toast } from '@/components/ui/sonner';
 
 import useClientApi from '@/hooks/use-client';
 import useClipboard from '@/hooks/use-clipboard';
@@ -58,7 +57,6 @@ export default function CopyButton({ className, title, content, data, children, 
 					: await axios.get(data.url).then((res) => res.data),
 		onSuccess: (data) => {
 			copy({ data, title, content });
-			toast(<Tran text="copied" />);
 		},
 	});
 

--- a/components/map/map-preview-card.tsx
+++ b/components/map/map-preview-card.tsx
@@ -33,7 +33,7 @@ function MapPreviewCard({ map: { id, name, likes, dislikes, downloadCount, itemI
 			<CopyButton position="absolute" variant="ghost" data={link} content={link}>
 				<Share2Icon />
 			</CopyButton>
-			<InternalLink href={detailLink}>
+			<InternalLink href={detailLink} prefetch={false}>
 				<PreviewImage src={imageLink} errorSrc={errorImageLink} alt={name} />
 			</InternalLink>
 			<PreviewDescription>

--- a/components/map/upload-map-preview-card.tsx
+++ b/components/map/upload-map-preview-card.tsx
@@ -33,7 +33,7 @@ function UploadMapPreviewCard({ map: { id, name } }: UploadMapPreviewCardProps) 
 				<Share2Icon />
 			</CopyButton>
 			<BulkActionSelector value={id}>
-				<InternalLink className="flex" href={detailLink}>
+				<InternalLink className="flex" href={detailLink} prefetch={false}>
 					<PreviewImage src={imageLink} errorSrc={errorImageLink} alt={name} />
 				</InternalLink>
 			</BulkActionSelector>

--- a/components/schematic/upload-schematic-preview-card.tsx
+++ b/components/schematic/upload-schematic-preview-card.tsx
@@ -45,7 +45,7 @@ function UploadSchematicPreviewCard({ schematic: { id, name } }: UploadSchematic
 				<Share2Icon />
 			</CopyButton>
 			<BulkActionSelector value={id}>
-				<InternalLink className="flex" href={detailLink}>
+				<InternalLink className="flex" href={detailLink} prefetch={false}>
 					<PreviewImage src={imageLink} errorSrc={errorImageLink} alt={name} />
 				</InternalLink>
 				<PreviewDescription>


### PR DESCRIPTION
- remove loading.tsx files and use Suspense with skeleton directly
- disable prefetch for internal links to reduce unnecessary requests
- move cached query functions to centralized action/query.ts
- simplify map-detail-card by moving data fetching to server component
- remove redundant toast notification in copy button