### PR TITLE
fix: handle NaN case in translation path icon value

### DIFF
--- a/app/[locale]/(main)/translation-path-icon.tsx
+++ b/app/[locale]/(main)/translation-path-icon.tsx
@@ -31,8 +31,10 @@ export function TranslationPathIcon() {
 		placeholderData: 0,
 	});
 
+	const value = diff + search;
+
 	return (
-		<NotificationNumber number={diff + search}>
+		<NotificationNumber number={Number.isNaN(value) ? 0 : value}>
 			<Globe />
 		</NotificationNumber>
 	);


### PR DESCRIPTION
Add NaN check before passing value to NotificationNumber to prevent potential display issues when the sum is not a number.