### PR TITLE
fix(usage-panel): correct cpu usage calculation and display

### DIFF
--- a/app/[locale]/(main)/servers/[id]/(dashboard)/usage-panel.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/usage-panel.tsx
@@ -25,7 +25,7 @@ export default function UsagePanel({ id, cpuUsage, ramUsage, totalRam }: UsagePa
 
 	const { cpu, ram } = useMemo(
 		() => ({
-			cpu: Math.round(data[0]?.value.cpuUsage ?? cpuUsage * 100) / 100,
+			cpu: (Math.round(data[0]?.value.cpuUsage ?? cpuUsage) * 100) / 100,
 			ram: (data[0]?.value.ramUsage ?? ramUsage) * 1024 * 1024,
 		}),
 		[cpuUsage, data, ramUsage],
@@ -37,7 +37,7 @@ export default function UsagePanel({ id, cpuUsage, ramUsage, totalRam }: UsagePa
 				<Tran className="font-bold" text="server.cpu-usage" />
 				<span className="text-muted-foreground">{cpu}%</span>
 			</div>
-			<CpuProgress value={cpuUsage} />
+			<CpuProgress value={cpu} />
 			<div className="flex gap-2 justify-between w-full">
 				<Tran className="font-bold" text="metric.ram-usage" />
 				<span className="text-muted-foreground">

--- a/components/server/cpu-progress.tsx
+++ b/components/server/cpu-progress.tsx
@@ -11,12 +11,17 @@ const CpuProgress = React.forwardRef<
 	React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
 >(({ className, value, ...props }, ref) => {
 	const [percent, setPercent] = React.useState(0);
+	const [max, setMax] = React.useState(100);
 
 	React.useEffect(() => {
-		const timeout = setTimeout(() => setPercent(Math.min(100, value || 0)), 50);
+		const fixed = value || 0;
+
+		const timeout = setTimeout(() => setPercent((fixed / max) * 100), 50);
+
+		setMax((prev) => (fixed > prev ? fixed : prev));
 
 		return () => clearTimeout(timeout);
-	}, [value]);
+	}, [max, value]);
 
 	return (
 		<ProgressPrimitive.Root


### PR DESCRIPTION
The CPU usage calculation was incorrectly rounding before multiplication, leading to inaccurate display. Also fixed the progress component to use the calculated value instead of the raw prop.