### PR TITLE
fix: correct timestamp calculation in stream text card

### DIFF
--- a/app/[locale]/(main)/servers/[id]/(dashboard)/stream-text-card.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/stream-text-card.tsx
@@ -7,7 +7,7 @@ export default function StreamTextCard({ index, current, first }: { index: numbe
 		<div className="gap-2 flex text-sm">
 			<span className="font-semibold text-nowrap">{index.toString().padStart(2, '0')}</span>
 			<ColorText className="text-sm text-muted-foreground" text={current.data} />
-			<span className="ml-auto text-nowrap">{Math.round((current.createdAt - first.createdAt) / 10) / 100}s</span>
+			<span className="ml-auto text-nowrap">{Math.round((current.createdAt - first.createdAt) / 100) / 10}s</span>
 		</div>
 	);
 }


### PR DESCRIPTION
The division by 10 was incorrectly placed in the timestamp calculation, leading to inaccurate time display. Fixed by moving the division by 100 before division by 10 to get correct seconds.