### PR TITLE
feat(server-stats): add jvm ram usage tracking and visualization

### DIFF
--- a/app/[locale]/(main)/servers/[id]/stats/page.tsx
+++ b/app/[locale]/(main)/servers/[id]/stats/page.tsx
@@ -2,7 +2,7 @@
 
 import { CheckCircleIcon, XCircleIcon } from 'lucide-react';
 import { RefreshCwIcon } from 'lucide-react';
-import { Suspense } from 'react';
+import { ReactNode, Suspense } from 'react';
 import { use, useMemo, useRef, useState } from 'react';
 import React from 'react';
 import { Line } from 'react-chartjs-2';
@@ -84,46 +84,68 @@ export default function Page({ params }: { params: Promise<{ id: string }> }) {
 			<Divider />
 			<ScrollContainer className="p-2 flex flex-col gap-2">
 				<div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-2">
-					<Suspense>
-						<LineChart
-							label="cpu"
-							unit="%"
-							maxTick={(server?.plan.cpu ?? 1) * 150}
-							metrics={
-								data?.map(({ createdAt, value }) => ({
-									createdAt: new Date(createdAt),
-									value: value.cpuUsage,
-								})) ?? []
-							}
-						/>
-					</Suspense>
-					<Suspense>
-						<LineChart
-							label="ram"
-							unit="Mb"
-							fill
-							maxTick={(server?.plan.ram ?? 1) * 1.2}
-							metrics={
-								data?.map(({ createdAt, value }) => ({
-									createdAt: new Date(createdAt),
-									value: value.ramUsage,
-								})) ?? []
-							}
-						/>
-					</Suspense>
-					<Suspense>
-						<LineChart
-							label="tps"
-							unit="Tick per second"
-							maxTick={70}
-							metrics={
-								data?.map(({ createdAt, value }) => ({
-									createdAt: new Date(createdAt),
-									value: value.tps,
-								})) ?? []
-							}
-						/>
-					</Suspense>
+					<LineChartWrapper>
+						<Suspense>
+							<LineChart
+								label="cpu"
+								unit="%"
+								maxTick={(server?.plan.cpu ?? 1) * 150}
+								metrics={
+									data?.map(({ createdAt, value }) => ({
+										createdAt: new Date(createdAt),
+										value: value.cpuUsage,
+									})) ?? []
+								}
+							/>
+						</Suspense>
+					</LineChartWrapper>
+					<LineChartWrapper>
+						<Suspense>
+							<LineChart
+								label="ram"
+								unit="Mb"
+								fill
+								maxTick={(server?.plan.ram ?? 1) * 1.2}
+								metrics={
+									data?.map(({ createdAt, value }) => ({
+										createdAt: new Date(createdAt),
+										value: value.ramUsage,
+									})) ?? []
+								}
+							/>
+						</Suspense>
+					</LineChartWrapper>
+					<LineChartWrapper>
+						<Suspense>
+							<LineChart
+								label="jvm-ram"
+								unit="Mb"
+								fill
+								maxTick={(server?.plan.ram ?? 1) * 1.2}
+								metrics={
+									data?.map(({ createdAt, value }) => ({
+										createdAt: new Date(createdAt),
+										value: value.jvmRamUsage,
+									})) ?? []
+								}
+							/>
+						</Suspense>
+					</LineChartWrapper>
+					<LineChartWrapper>
+						<Suspense>
+							<LineChart
+								label="tps"
+								unit="Tick per second"
+								maxTick={70}
+								metrics={
+									data?.map(({ createdAt, value }) => ({
+										createdAt: new Date(createdAt),
+										value: value.tps,
+									})) ?? []
+								}
+							/>
+						</Suspense>
+					</LineChartWrapper>
 					<Suspense>
 						<LoginLogChart serverId={id} filter={filter} />
 					</Suspense>
@@ -131,6 +153,10 @@ export default function Page({ params }: { params: Promise<{ id: string }> }) {
 			</ScrollContainer>
 		</div>
 	);
+}
+
+function LineChartWrapper({ children }: { children: ReactNode }) {
+	return <div className="aspect-video h-auto w-full flex overflow-hidden rounded-lg border bg-card">{children}</div>;
 }
 
 function LineChart({
@@ -161,49 +187,47 @@ function LineChart({
 	const unitLabel = unit ? `(${unit})` : '';
 
 	return (
-		<div className="aspect-video h-auto w-full flex overflow-hidden rounded-lg border bg-card">
-			<Line
-				className="p-2"
-				options={{
-					animations: {
-						y: {
-							duration: 0,
+		<Line
+			className="p-2"
+			options={{
+				animations: {
+					y: {
+						duration: 0,
+					},
+				},
+				responsive: true,
+				aspectRatio: 16 / 9,
+				scales: {
+					x: {
+						ticks: {
+							maxTicksLimit: 15,
 						},
 					},
-					responsive: true,
-					aspectRatio: 16 / 9,
-					scales: {
-						x: {
-							ticks: {
-								maxTicksLimit: 15,
-							},
-						},
-						y: {
-							max: maxTick,
-							beginAtZero: true,
-							ticks: {
-								precision: 0,
-							},
+					y: {
+						max: maxTick,
+						beginAtZero: true,
+						ticks: {
+							precision: 0,
 						},
 					},
-				}}
-				data={{
-					labels: metrics.map(
-						({ createdAt }) =>
-							`${createdAt.getMinutes().toString().padStart(2, '0')}:${createdAt.getSeconds().toString().padStart(2, '0')}`,
-					),
-					datasets: [
-						{
-							label: `${t(label)} ${unitLabel} avg: ${avg} ${unitLabel} min: ${min} ${unitLabel} max: ${max} ${unitLabel}`,
-							data: metrics.map(({ value }) => value),
-							fill,
-							borderColor,
-							backgroundColor,
-						},
-					],
-				}}
-			/>
-		</div>
+				},
+			}}
+			data={{
+				labels: metrics.map(
+					({ createdAt }) =>
+						`${createdAt.getMinutes().toString().padStart(2, '0')}:${createdAt.getSeconds().toString().padStart(2, '0')}`,
+				),
+				datasets: [
+					{
+						label: `${t(label)} ${unitLabel} avg: ${avg} ${unitLabel} min: ${min} ${unitLabel} max: ${max} ${unitLabel}`,
+						data: metrics.map(({ value }) => value),
+						fill,
+						borderColor,
+						backgroundColor,
+					},
+				],
+			}}
+		/>
 	);
 }
 

--- a/components/metric/ram-usage-chart.tsx
+++ b/components/metric/ram-usage-chart.tsx
@@ -38,9 +38,9 @@ export default function RamUsageChart({ serverRamUsage, nativeRamUsage, totalRam
 	}, [nativePercentUsage]);
 
 	return (
-		<ProgressPrimitive.Root className={cn('relative h-2 w-full overflow-hidden rounded-full bg-primary/20')}>
+		<ProgressPrimitive.Root className={cn('relative h-2 w-full overflow-hidden rounded-full bg-primary/20 divide-y')}>
 			<ProgressPrimitive.Indicator
-				className="h-full w-full flex-1 transition-all duration-500"
+				className="h-full w-full flex-1 transition-all duration-500 z-10"
 				style={{
 					transform: `translateX(-${100 + serverPercent - nativePercent}%)`,
 					backgroundColor:
@@ -52,7 +52,7 @@ export default function RamUsageChart({ serverRamUsage, nativeRamUsage, totalRam
 				}}
 			/>
 			<ProgressPrimitive.Indicator
-				className="h-full w-full flex-1 transition-all duration-500"
+				className="h-full w-full flex-1 transition-all duration-500 z-20 border-r border-white"
 				style={{
 					transform: `translateX(-${100 - serverPercent}%)`,
 					backgroundColor:

--- a/components/metric/ram-usage-chart.tsx
+++ b/components/metric/ram-usage-chart.tsx
@@ -7,36 +7,58 @@ import { cn } from '@/lib/utils';
 import * as ProgressPrimitive from '@radix-ui/react-progress';
 
 type Props = {
-	ramUsage: number;
+	serverRamUsage: number;
+	nativeRamUsage: number;
 	totalRam: number;
 };
 
-export default function RamUsageChart({ ramUsage, totalRam }: Props) {
-	ramUsage = isNaN(ramUsage) ? 0 : ramUsage;
+export default function RamUsageChart({ serverRamUsage, nativeRamUsage, totalRam }: Props) {
+	serverRamUsage = isNaN(serverRamUsage) ? 0 : serverRamUsage;
 	totalRam = isNaN(totalRam) ? 0 : totalRam;
 
-	let percentUsage = Math.round((ramUsage / totalRam) * 10000) / 100;
+	let serverPercentUsage = Math.round((serverRamUsage / totalRam) * 10000) / 100;
+	let nativePercentUsage = Math.round((nativeRamUsage / totalRam) * 10000) / 100;
 
-	percentUsage = isNaN(percentUsage) ? 0 : percentUsage;
+	serverPercentUsage = isNaN(serverPercentUsage) ? 0 : serverPercentUsage;
+	nativePercentUsage = isNaN(nativePercentUsage) ? 0 : nativePercentUsage;
 
-	const [percent, setPercent] = React.useState(0);
+	const [nativePercent, setNativePercent] = React.useState(0);
+	const [serverPercent, setServerPercent] = React.useState(0);
 
 	React.useEffect(() => {
-		const timeout = setTimeout(() => setPercent(percentUsage || 0), 100);
+		const timeout = setTimeout(() => setServerPercent(serverPercentUsage || 0), 100);
 
 		return () => clearTimeout(timeout);
-	}, [percentUsage]);
+	}, [serverPercentUsage]);
+
+	React.useEffect(() => {
+		const timeout = setTimeout(() => setNativePercent(nativePercentUsage || 0), 100);
+
+		return () => clearTimeout(timeout);
+	}, [nativePercentUsage]);
 
 	return (
 		<ProgressPrimitive.Root className={cn('relative h-2 w-full overflow-hidden rounded-full bg-primary/20')}>
 			<ProgressPrimitive.Indicator
 				className="h-full w-full flex-1 transition-all duration-500"
 				style={{
-					transform: `translateX(-${100 - (percent || 0)}%)`,
+					transform: `translateX(-${100 + serverPercent - nativePercent}%)`,
 					backgroundColor:
-						percentUsage < 50
+						nativePercent < 50
 							? 'green' //
-							: percentUsage < 70
+							: nativePercent < 70
+								? 'gold'
+								: 'red',
+				}}
+			/>
+			<ProgressPrimitive.Indicator
+				className="h-full w-full flex-1 transition-all duration-500"
+				style={{
+					transform: `translateX(-${100 - serverPercent}%)`,
+					backgroundColor:
+						serverPercent < 50
+							? 'green' //
+							: serverPercent < 70
 								? 'gold'
 								: 'red',
 				}}

--- a/types/response/ServerDto.ts
+++ b/types/response/ServerDto.ts
@@ -13,6 +13,7 @@ export type ServerDto = {
 	gamemode?: string;
 	status: ServerStatus;
 	ramUsage: number;
+	jvmRamUsage: number;
 	cpuUsage: number;
 	totalRam: number;
 	players: number;

--- a/types/response/ServerStats.ts
+++ b/types/response/ServerStats.ts
@@ -3,6 +3,7 @@ import { ServerStatus } from '@/constant/constant';
 export type ServerStats = {
 	tps: number;
 	ramUsage: number;
+	jvmRamUsage: number;
 	totalRam: number;
 	cpuUsage: number;
 	players: number;


### PR DESCRIPTION
- Add jvmRamUsage field to ServerDto and ServerStats types
- Update usage panel to display both server and native RAM usage
- Modify ram usage chart to show separate server and native RAM usage
- Add new jvm-ram chart to stats page
- Create LineChartWrapper component for consistent chart styling