### PR TITLE
fix(i18n): improve error logging in translation fetch

### DIFF
--- a/i18n/server.ts
+++ b/i18n/server.ts
@@ -31,7 +31,7 @@ const getTranslationCached = cache(
 					return await res.json();
 				});
 			} catch (error) {
-				console.error('Fail to fetch: ' + url);
+				console.error('Fail to fetch: ' + url + " " + error);
 				return Promise.reject(error);
 			}
 		},


### PR DESCRIPTION
Include the actual error in the console output when translation fetch fails to help with debugging