### PR TITLE
refactor(error-handling): simplify error serialization across modules

### DIFF
--- a/action/common.ts
+++ b/action/common.ts
@@ -36,14 +36,11 @@ export async function catchError<T>(axios: AxiosInstance, queryFn: ServerApi<T>)
 	} catch (error) {
 		if (isAxiosError(error)) {
 			return {
-				error: {
-					message: `${error.config?.method?.toUpperCase()} ${error.request?.url} ${error.message}\n${error.response?.data.message}`,
-					cause: error.toJSON(),
-				},
+				error: `${error.config?.method?.toUpperCase()} ${error.request?.url} ${error.message}\n${error.response?.data.message}`,
 			};
 		}
 		return {
-			error: JSON.stringify(error, Object.getOwnPropertyNames(error)),
+			error: JSON.stringify(error),
 		};
 	}
 }

--- a/action/common.ts
+++ b/action/common.ts
@@ -36,7 +36,9 @@ export async function catchError<T>(axios: AxiosInstance, queryFn: ServerApi<T>)
 	} catch (error) {
 		if (isAxiosError(error)) {
 			return {
-				error: `${error.config?.method?.toUpperCase()} ${error.request?.url} ${error.message}\n${error.response?.data.message}`,
+				error: new Error(
+					`${error.config?.method?.toUpperCase()} ${error.request?.url} ${error.message}\n${error.response?.data.message}`,
+				),
 			};
 		}
 		return {

--- a/components/common/error-message.tsx
+++ b/components/common/error-message.tsx
@@ -1,11 +1,9 @@
-'use client';
-
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import ReportErrorDialog from '@/components/common/report-error.dialog';
 import Tran from '@/components/common/tran';
 
-import { getErrorMessage, reportError } from '@/lib/error';
+import { getErrorMessage } from '@/lib/error';
 import { cn } from '@/lib/utils';
 
 type Props = {
@@ -15,14 +13,10 @@ type Props = {
 export default function ErrorMessage({ className, error }: Props) {
 	const message = getErrorMessage(error);
 
-	useEffect(() => {
-		console.error(error);
-		reportError(error);
-	}, [error]);
-
 	if (message) {
 		return (
 			<span className={cn('text-destructive-foreground font-semibold p-2 text-sm space-x-1', className)}>
+				<span className="font-semibold">{typeof window === 'undefined' ? 'SERVER' : 'CLIENT'}: </span>
 				<span>{message}</span>
 				<ReportErrorDialog />
 			</span>

--- a/i18n/client.ts
+++ b/i18n/client.ts
@@ -47,7 +47,7 @@ const getTranslationCached = cache(async (url: string) => {
 			return await res.json();
 		});
 	} catch (error) {
-		console.error('Failed to fetch client translation: ' + url + ' ' + JSON.stringify(error, Object.getOwnPropertyNames(error)));
+		console.error('Failed to fetch client translation: ' + url + ' ' + JSON.stringify(error));
 		return Promise.reject(error);
 	}
 });

--- a/i18n/server.ts
+++ b/i18n/server.ts
@@ -45,9 +45,7 @@ const getTranslationCached = cache(
 					return await res.json();
 				});
 			} catch (error) {
-				console.error(
-					'Fail to fetch server translation: ' + url + ' ' + JSON.stringify(error, Object.getOwnPropertyNames(error)),
-				);
+				console.error('Fail to fetch server translation: ' + url + ' ' + JSON.stringify(error));
 				return Promise.reject(error);
 			}
 		},

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -22,7 +22,7 @@ export function onRequestError(
 					'Content-Type': 'application/json',
 				},
 				body: JSON.stringify({
-					message: JSON.stringify({ error: JSON.stringify(error, Object.getOwnPropertyNames(error)), request, context }),
+					message: JSON.stringify({ error: JSON.stringify(error), request, context }),
 				}),
 			});
 		} catch (error) {


### PR DESCRIPTION
Remove Object.getOwnPropertyNames from error serialization to use default JSON.stringify behavior