### PR TITLE
feat(analytics): add RabbitMQ icon and navigation item

### DIFF
--- a/app/[locale]/(main)/medium-navigation-items.tsx
+++ b/app/[locale]/(main)/medium-navigation-items.tsx
@@ -1,30 +1,10 @@
 'use client';
 
-import {
-	BookIcon,
-	BookOpenIcon,
-	BotIcon,
-	BoxIcon,
-	ClipboardList,
-	CrownIcon,
-	FileIcon,
-	Folder,
-	HistoryIcon,
-	HomeIcon,
-	ImageIcon,
-	LineChart,
-	LogIn,
-	MapIcon,
-	MessageSquareIcon,
-	PlugIcon,
-	ServerIcon,
-	Sigma,
-	SquareKanbanIcon,
-	TerminalIcon,
-	UploadIcon,
-} from 'lucide-react';
+import { BookIcon, BookOpenIcon, BotIcon, BoxIcon, ClipboardList, CrownIcon, FileIcon, Folder, HistoryIcon, HomeIcon, ImageIcon, LineChart, LogIn, MapIcon, MessageSquareIcon, PlugIcon, ServerIcon, Sigma, SquareKanbanIcon, TerminalIcon, UploadIcon } from 'lucide-react';
 import React from 'react';
 import { ReactNode } from 'react';
+
+
 
 import { MessageCircleIconPath } from '@/app/[locale]/(main)/chat-icon-path';
 import { LogPathIcon } from '@/app/[locale]/(main)/log-path';
@@ -44,16 +24,21 @@ import { TranslationPathIcon } from '@/app/[locale]/(main)/translation-path-icon
 import { UserDisplay } from '@/app/[locale]/(main)/user-display';
 import { VerifyPathIcon } from '@/app/[locale]/(main)/verify-path-icon';
 
+
+
 import ErrorMessage from '@/components/common/error-message';
 import Hydrated from '@/components/common/hydrated';
 import Tran from '@/components/common/tran';
 import Divider from '@/components/ui/divider';
+
+
 
 import { useSession } from '@/context/session.context';
 import { locales } from '@/i18n/config';
 import ProtectedElement from '@/layout/protected-element';
 import { isError } from '@/lib/error';
 import { Filter } from '@/lib/utils';
+
 
 const localesRegex = `/(${locales.join('|')})`;
 
@@ -454,6 +439,14 @@ export const groups: readonly PathGroup[] = [
 						regex: [`^${localesRegex}/analytic/google`],
 						prefetch: false,
 					},
+					{
+						id: 'rabbitmq',
+						name: 'RabbitMQ',
+						path: 'https://analytic.mindustry-tool.com:15672',
+						icon: <RabbitMQIcon />,
+						regex: [`^${localesRegex}/analytic/rabbitmq`],
+						prefetch: false,
+					},
 				],
 				name: <Tran asChild text="analytic" />,
 				icon: <LineChart />,
@@ -536,6 +529,17 @@ function GoogleIcon() {
 			<path
 				fill="#319f43"
 				d="M8.75 92.4q10.37-8 20.73-16.08A39.3 39.3 0 0044 95.74a37.16 37.16 0 0014.08 6.08 41.29 41.29 0 0015.1 0 36.16 36.16 0 0013.93-5.5c6.69 5.22 13.41 10.4 20.1 15.62a57.13 57.13 0 01-25.9 13.47 67.6 67.6 0 01-32.36-.35 63 63 0 01-23-11.59A63.73 63.73 0 018.75 92.4z"
+			></path>
+		</svg>
+	);
+}
+
+function RabbitMQIcon() {
+	return (
+		<svg viewBox="0 0 128 128">
+			<path
+				fill="#ff6600"
+				d="M119.517 51.188H79.291a3.641 3.641 0 0 1-3.64-3.642V5.62A5.605 5.605 0 0 0 70.028 0H55.66a5.606 5.606 0 0 0-5.627 5.62v41.646a3.913 3.913 0 0 1-3.92 3.925l-13.188.047c-2.176 0-3.972-1.75-3.926-3.926l.094-41.687A5.606 5.606 0 0 0 23.467 0H9.1a5.61 5.61 0 0 0-5.626 5.625V122.99c0 2.737 2.22 5.01 5.01 5.01h111.033a5.014 5.014 0 0 0 5.008-5.011V56.195a4.975 4.975 0 0 0-5.008-5.007zM100.66 95.242a6.545 6.545 0 0 1-6.525 6.524H82.791a6.545 6.545 0 0 1-6.523-6.524V83.9a6.545 6.545 0 0 1 6.523-6.524h11.343a6.545 6.545 0 0 1 6.525 6.523zm0 0"
 			></path>
 		</svg>
 	);


### PR DESCRIPTION
Add new RabbitMQ analytics section with external link to RabbitMQ management UI. The icon is implemented as a custom SVG component.