### PR TITLE
refactor(utils): move error logging outside retry loop in withRetry

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -477,10 +477,11 @@ export async function withRetry<T>(fn: () => Promise<T>, retries: number): Promi
 			return await fn();
 		} catch (e) {
 			attempts++;
-			console.warn(e);
 			errors.push(e);
 		}
 	}
 
-	throw new Error('Max retries reached', { cause: errors });
+	console.warn(errors);
+
+	throw new Error(`Max retries reached: ${attempts}/${retries}`, { cause: errors });
 }


### PR DESCRIPTION
Move console.warn outside the retry loop to avoid duplicate logging and only show aggregated errors when max retries are reached