### PR TITLE
fix(usage-panel): correct ram usage percentage calculation

### DIFF
--- a/app/[locale]/(main)/servers/[id]/(dashboard)/usage-panel.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/usage-panel.tsx
@@ -50,7 +50,7 @@ export default function UsagePanel({ id, cpuUsage, jvmRamUsage, ramUsage, totalR
 				<Tran className="font-bold" text="metric.ram-usage" />
 				<span className="text-muted-foreground">
 					{byteToSize(jvmRamUsage * 1024 * 1024)} / {byteToSize(totalRam * 1024 * 1024)} (
-					{Math.ceil(((jvmRamUsage ?? 1) / (totalRam ?? 1)) * 10) / 100}%)
+					{Math.ceil(((jvmRamUsage ?? 1) / (totalRam ?? 1)) * 10000) / 100}%)
 				</span>
 			</div>
 			<RamUsageChart serverRamUsage={serverRam} nativeRamUsage={nativeRam} totalRam={totalRam * 1024 * 1024} />

--- a/components/server/ban.button.tsx
+++ b/components/server/ban.button.tsx
@@ -37,15 +37,15 @@ export function BanButton({ id, ip, uuid, username }: BanButtonProps) {
 
 	function handleBan() {
 		if (ip) {
-			sendMessage(`/ban add ip ${ip}`);
+			sendMessage(`/ban ip ${ip}`);
 		}
 
 		if (uuid) {
-			sendMessage(`/ban add id ${uuid}`);
+			sendMessage(`/ban id ${uuid}`);
 		}
 
 		if (username) {
-			sendMessage(`/ban add name ${username}`);
+			sendMessage(`/ban name ${username}`);
 		}
 
 		setTimeout(() => {


### PR DESCRIPTION
The calculation was incorrectly multiplying by 10 instead of 10000 to get the percentage, resulting in inaccurate display of RAM usage percentages.