### PR TITLE
fix: simplify error logging by removing JSON stringify

### DIFF
--- a/lib/error.ts
+++ b/lib/error.ts
@@ -106,7 +106,7 @@ export function isError<T extends Record<string, any> | number>(req: T | Error |
 
 	if (isError && !ignoredErrors.includes(req.name)) {
 		try {
-			console.error(JSON.stringify(req, null, 2));
+			console.error(req);
 			reportError(req);
 		} catch (e) {
 			console.error(e);


### PR DESCRIPTION
The previous JSON.stringify output was unnecessarily verbose for error logging. The raw error object provides sufficient information and is more readable in logs.