### PR TITLE
fix(servers): show loading spinner instead of empty fragment during m…

### DIFF
--- a/app/[locale]/(main)/servers/[id]/(dashboard)/has-server-map.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/has-server-map.tsx
@@ -8,11 +8,7 @@ import useServerMaps from '@/hooks/use-server-maps';
 export default function HasServerMap({ id, children }: { id: string; children: ReactNode }) {
 	const { data, isError, isLoading } = useServerMaps(id);
 
-	if (isLoading) {
-		return <></>;
-	}
-
-	if (isError || !data || data.length === 0) {
+	if ((isError || !data || data.length === 0) && !isLoading) {
 		return (
 			<div className="space-x-2 h-9 rounded-md">
 				<Tran className="text-warning-foreground" text="server.no-map-warning" />


### PR DESCRIPTION
…ap load

Replace empty fragment with LoadingSpinner component to provide better user feedback while server maps are loading