### PR TITLE
fix(dashboard): prevent empty render during server map loading

### DIFF
--- a/app/[locale]/(main)/servers/[id]/(dashboard)/has-server-map.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/has-server-map.tsx
@@ -8,11 +8,7 @@ import useServerMaps from '@/hooks/use-server-maps';
 export default function HasServerMap({ id, children }: { id: string; children: ReactNode }) {
 	const { data, isError, isLoading } = useServerMaps(id);
 
-	if (isLoading) {
-		return <></>;
-	}
-
-	if (isError || !data || data.length === 0) {
+	if ((isError || !data || data.length === 0) && !isLoading) {
 		return (
 			<div className="space-x-2 h-9 rounded-md">
 				<Tran className="text-warning-foreground" text="server.no-map-warning" />


### PR DESCRIPTION
Ensure the component only renders the warning when not in loading state to avoid flickering UI