### PR TITLE
refactor(usage-panel): remove unnecessary useMemo for simple calculat…

### DIFF
--- a/app/[locale]/(main)/servers/[id]/(dashboard)/usage-panel.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/usage-panel.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { useMemo } from 'react';
-
 import Tran from '@/components/common/tran';
 import RamUsageChart from '@/components/metric/ram-usage-chart';
 import CpuProgress from '@/components/server/cpu-progress';
@@ -28,15 +26,9 @@ export default function UsagePanel({ id, cpuUsage, jvmRamUsage, ramUsage, totalR
 		limit: 1,
 	});
 
-	const { cpu, serverRam, jvmRam } = useMemo(
-		() => ({
-			cpu: (Math.ceil(data[0]?.value.cpuUsage ?? cpuUsage ?? 0) * 100) / 100,
-			serverRam: (data[0]?.value.ramUsage ?? ramUsage ?? 0) * 1024 * 1024,
-			jvmRam: (data[0]?.value.jvmRamUsage ?? jvmRamUsage ?? 0) * 1024 * 1024,
-		}),
-		[cpuUsage, jvmRamUsage, ramUsage, data],
-	);
-
+	const cpu = (Math.ceil(data[0]?.value.cpuUsage ?? cpuUsage ?? 0) * 100) / 100;
+	const serverRam = (data[0]?.value.ramUsage ?? ramUsage ?? 0) * 1024 * 1024;
+	const jvmRam = (data[0]?.value.jvmRamUsage ?? jvmRamUsage ?? 0) * 1024 * 1024;
 	const nativeRam = jvmRam - serverRam;
 
 	return (

--- a/app/[locale]/(main)/servers/[id]/(dashboard)/usage-panel.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/usage-panel.tsx
@@ -25,9 +25,9 @@ export default function UsagePanel({ id, cpuUsage, jvmRamUsage, ramUsage, plan }
 		limit: 1,
 	});
 
-	const cpu = (Math.ceil(data[0]?.value.cpuUsage ?? cpuUsage ?? 0) * 100) / 100;
-	const serverRam = (data[0]?.value.ramUsage ?? ramUsage ?? 0) * 1024 * 1024;
-	const jvmRam = (data[0]?.value.jvmRamUsage ?? jvmRamUsage ?? 0) * 1024 * 1024;
+	const cpu = (Math.ceil(data[data.length - 1]?.value.cpuUsage ?? cpuUsage ?? 0) * 100) / 100;
+	const serverRam = (data[data.length - 1]?.value.ramUsage ?? ramUsage ?? 0) * 1024 * 1024;
+	const jvmRam = (data[data.length - 1]?.value.jvmRamUsage ?? jvmRamUsage ?? 0) * 1024 * 1024;
 	const totalRam = plan.ram;
 	const nativeRam = jvmRam - serverRam;
 

--- a/app/[locale]/(main)/servers/[id]/(dashboard)/usage-panel.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/usage-panel.tsx
@@ -17,11 +17,10 @@ type UsagePanelProps = {
 	cpuUsage: number;
 	ramUsage: number;
 	jvmRamUsage: number;
-	totalRam: number;
 	plan: ServerPlan;
 };
 
-export default function UsagePanel({ id, cpuUsage, jvmRamUsage, ramUsage, totalRam, plan }: UsagePanelProps) {
+export default function UsagePanel({ id, cpuUsage, jvmRamUsage, ramUsage, plan }: UsagePanelProps) {
 	const { data } = useSse<ServerLiveStats>(`${env.url.api}/servers/${id}/live-stats`, {
 		limit: 1,
 	});
@@ -29,6 +28,7 @@ export default function UsagePanel({ id, cpuUsage, jvmRamUsage, ramUsage, totalR
 	const cpu = (Math.ceil(data[0]?.value.cpuUsage ?? cpuUsage ?? 0) * 100) / 100;
 	const serverRam = (data[0]?.value.ramUsage ?? ramUsage ?? 0) * 1024 * 1024;
 	const jvmRam = (data[0]?.value.jvmRamUsage ?? jvmRamUsage ?? 0) * 1024 * 1024;
+	const totalRam = plan.ram;
 	const nativeRam = jvmRam - serverRam;
 
 	return (


### PR DESCRIPTION
…ions

The useMemo hook was removed for simple calculations that don't benefit from memoization, simplifying the code while maintaining the same functionality.