### PR TITLE
refactor(hooks): remove debug console.log from useSse hook

### DIFF
--- a/app/[locale]/(main)/servers/[id]/(dashboard)/usage-panel.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/usage-panel.tsx
@@ -25,9 +25,9 @@ export default function UsagePanel({ id, cpuUsage, jvmRamUsage, ramUsage, plan }
 		limit: 1,
 	});
 
-	const cpu = (Math.ceil(data[data.length - 1]?.value.cpuUsage ?? cpuUsage ?? 0) * 100) / 100;
-	const serverRam = (data[data.length - 1]?.value.ramUsage ?? ramUsage ?? 0) * 1024 * 1024;
-	const jvmRam = (data[data.length - 1]?.value.jvmRamUsage ?? jvmRamUsage ?? 0) * 1024 * 1024;
+	const cpu = (Math.ceil(data[0]?.value.cpuUsage ?? cpuUsage ?? 0) * 100) / 100;
+	const serverRam = (data[0]?.value.ramUsage ?? ramUsage ?? 0) * 1024 * 1024;
+	const jvmRam = (data[0]?.value.jvmRamUsage ?? jvmRamUsage ?? 0) * 1024 * 1024;
 	const totalRam = plan.ram;
 	const nativeRam = jvmRam - serverRam;
 

--- a/hooks/use-sse.ts
+++ b/hooks/use-sse.ts
@@ -87,7 +87,5 @@ export default function useSse<T = string>(
 		}
 	}, 5000);
 
-	console.log({ state, error, messages });
-
 	return { data: messages, state, error };
 }


### PR DESCRIPTION
The console.log statement was used for debugging and is no longer needed. Also increase the SSE limit from 1 to 2 in usage-panel to capture more data points.