### PR TITLE
fix(usage-panel): correct ram usage calculation and display

### DIFF
--- a/app/[locale]/(main)/servers/[id]/(dashboard)/usage-panel.tsx
+++ b/app/[locale]/(main)/servers/[id]/(dashboard)/usage-panel.tsx
@@ -41,8 +41,8 @@ export default function UsagePanel({ id, cpuUsage, jvmRamUsage, ramUsage, plan }
 			<div className="flex gap-2 justify-between w-full">
 				<Tran className="font-bold" text="metric.ram-usage" />
 				<span className="text-muted-foreground">
-					{byteToSize(jvmRam * 1024 * 1024)} / {byteToSize(totalRam * 1024 * 1024)} (
-					{Math.ceil(((jvmRam ?? 1) / (totalRam ?? 1)) * 10000) / 100}%)
+					{byteToSize(jvmRam)} / {byteToSize(totalRam * 1024 * 1024)} (
+					{Math.ceil(((jvmRam ?? 1) / (totalRam ?? 1)) * 1024 * 1024 * 10000) / 100}%)
 				</span>
 			</div>
 			<RamUsageChart serverRamUsage={serverRam} nativeRamUsage={nativeRam} totalRam={totalRam * 1024 * 1024} />


### PR DESCRIPTION
The calculation for RAM usage percentage was incorrect due to missing unit conversion. Fixed the display format to properly show used RAM in bytes and total RAM in MB, and corrected the percentage calculation by applying proper unit conversions.